### PR TITLE
fix: center footer timestamp and unify sign-in footer

### DIFF
--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -287,9 +287,12 @@ struct PopoverView: View {
     // MARK: - Footer
 
     private var footer: some View {
-        HStack {
-            Button("Settings") { openSettingsKeepingPopover() }
-            Spacer()
+        ZStack {
+            HStack {
+                Button("Settings") { openSettingsKeepingPopover() }
+                Spacer()
+                Button("Quit", role: .destructive) { NSApp.terminate(nil) }
+            }
             if let date = viewModel.lastRefreshedAt {
                 TimelineView(.periodic(from: date, by: 60)) { _ in
                     Text(date.relativeFormatted)
@@ -297,8 +300,6 @@ struct PopoverView: View {
                         .foregroundStyle(.tertiary)
                 }
             }
-            Spacer()
-            Button("Quit", role: .destructive) { NSApp.terminate(nil) }
         }
         .buttonStyle(.borderless)
         .font(.body)
@@ -339,6 +340,7 @@ struct PopoverView: View {
             .padding(24)
             Divider()
             HStack {
+                Button("Settings") { openSettingsKeepingPopover() }
                 Spacer()
                 Button("Quit", role: .destructive) { NSApp.terminate(nil) }
             }


### PR DESCRIPTION
## Summary

- Use `ZStack` in the authenticated footer so `Just now` is pixel-perfect centered regardless of `Settings`/`Quit` button widths
- Add `Settings` button to the sign-in footer so both states share the same layout structure
- Sign-in footer retains its original compact font (`.footnote`) and padding

## Test plan

- [ ] Authenticated view: verify `Just now` is visually centered between Settings and Quit
- [ ] Sign-in view: verify Settings and Quit are present and match original spacing/font
- [ ] Click Settings and Quit in both states to confirm hit targets work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)