### PR TITLE
feat: add support links to Settings, remove notification test UI

### DIFF
--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -312,10 +312,4 @@ final class QuotaViewModel {
         if isCodexAuthenticated || isClaudeAuthenticated { startAutoRefresh() }
     }
 
-    // MARK: - Notification testing
-
-    func testNotifications() async {
-        await NotificationManager.shared.requestPermission()
-        await NotificationManager.shared.fireTestNotifications()
-    }
 }

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -40,9 +40,6 @@ struct SettingsView: View {
 
                 if viewModel.settings.notificationsEnabled {
                     NotificationStatusRow()
-                    Button("Send test notification") {
-                        Task { await viewModel.testNotifications() }
-                    }
                 }
             }
 
@@ -80,6 +77,15 @@ struct SettingsView: View {
                         .fontWeight(.medium)
                     Text("Made by John Niedermeyer, with a little help from\nClaude, Codex and friends.")
                         .multilineTextAlignment(.center)
+                    Text("Need Help?")
+                        .padding(.top, 4)
+                    HStack(spacing: 12) {
+                        Link("GitHub Issues", destination: URL(string: "https://github.com/niederme/ai-quota/issues")!)
+                            .foregroundColor(Color(red: 0.62, green: 0.22, blue: 0.93))
+                        Text("·").foregroundStyle(.quaternary)
+                        Link("@niederme on X", destination: URL(string: "https://x.com/niederme")!)
+                            .foregroundColor(Color(red: 0.62, green: 0.22, blue: 0.93))
+                    }
                 }
                 .font(.callout)
                 .foregroundStyle(.tertiary)

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Notifications/NotificationManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Notifications/NotificationManager.swift
@@ -213,27 +213,6 @@ public actor NotificationManager {
         }
     }
 
-    // MARK: - Test helper
-
-    /// Fires all notification types with a 2-second gap. For development/QA only.
-    public func fireTestNotifications() async {
-        let notifications: [(String, String, String)] = [
-            ("test.codex.below15",          "Codex quota low",              "Less than 15% of your weekly Codex quota remains."),
-            ("test.codex.below5",           "Codex quota critical",         "Less than 5% of your weekly Codex quota remains."),
-            ("test.codex.limitReached",     "Codex quota reached",          "Your weekly Codex quota is fully used. Resets in 9h 30m."),
-            ("test.codex.reset",            "Codex quota reset",            "Your weekly Codex quota has reset — you're back to 100%."),
-            ("test.claude.below15",         "Claude quota low",             "Less than 15% of your Claude 5-hour window capacity remains."),
-            ("test.claude.limitReached",    "Claude rate limit reached",    "Your 5-hour Claude window is fully used. Resets in 2h 15m."),
-            ("test.claude.7day80",          "Claude 7-day usage high",      "You've used 80% of your 7-day Claude allowance — consider slowing down."),
-            ("test.claude.7day95",          "Claude 7-day limit critical",  "You've used 95% of your 7-day Claude allowance. Resets in 4d 12h."),
-            ("test.claude.7dayLimit",       "Claude 7-day limit reached",   "Your 7-day Claude allowance is fully used. Resets in 4d 12h."),
-        ]
-        for (id, title, body) in notifications {
-            await send(id: id, title: title, body: body)
-            do { try await Task.sleep(for: .seconds(2)) } catch {}
-        }
-    }
-
     // MARK: - Private helpers
 
     private func send(id: String, title: String, body: String) async {


### PR DESCRIPTION
## Summary
- Removes the "Send test notification" button from Settings (and the backing `testNotifications`/`fireTestNotifications` methods)
- Adds a "Need Help?" section to the Settings footer with **GitHub Issues** and **@niederme on X** links, styled in the app's branded purple

## Test plan
- [ ] Open Settings → Notifications — confirm no test button
- [ ] Scroll to bottom of Settings — confirm "Need Help?" label with two purple links
- [ ] Click "GitHub Issues" → opens `github.com/niederme/ai-quota/issues`
- [ ] Click "@niederme on X" → opens `x.com/niederme`