### PR TITLE
fix: eliminate false-positive network banner and sign-in hang on first launch

### DIFF
--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -61,6 +61,9 @@ final class QuotaViewModel {
     /// Tracks whether the last known network path was unsatisfied so we can
     /// detect a transition back online and refresh immediately.
     private var wasOffline = false
+    /// Set to true once NWPathMonitor fires its first update. Prevents false-positive
+    /// "No network connection" banners at launch before the monitor has settled.
+    private var pathMonitorReady = false
     private let pathMonitor = NWPathMonitor()
     private let pathMonitorQueue = DispatchQueue(label: "ai.quota.pathmonitor")
 
@@ -117,6 +120,7 @@ final class QuotaViewModel {
             guard let self else { return }
             let isNowSatisfied = path.status == .satisfied
             DispatchQueue.main.async {
+                self.pathMonitorReady = true
                 if isNowSatisfied {
                     // Always clear stale network-unavailable banners when path is
                     // satisfied — catches the launch-time false-positive where the
@@ -201,8 +205,9 @@ final class QuotaViewModel {
             logger.warning("[CodexRefresh] unexpected error: \(error) | path: \(String(describing: pathStatus)) | urlErrCode: \(String(describing: (error as? URLError)?.code.rawValue))")
             // Only surface as network-unavailable if the error is truly connectivity-
             // related, or if NWPathMonitor independently confirms we're offline.
-            // Avoids false-positive banners from transient SSL/timeout/server errors.
-            if isConnectivityError(error) || pathStatus != .satisfied {
+            // Require pathMonitorReady to avoid false-positives at launch before
+            // the monitor has fired its first update.
+            if isConnectivityError(error) || (pathMonitorReady && pathStatus != .satisfied) {
                 codexError = .networkUnavailable
             }
         }
@@ -242,7 +247,9 @@ final class QuotaViewModel {
             logger.warning("[ClaudeRefresh] unexpected error: \(error) | path: \(String(describing: pathStatus)) | urlErrCode: \(String(describing: (error as? URLError)?.code.rawValue))")
             // Only surface as network-unavailable if the error is truly connectivity-
             // related, or if NWPathMonitor independently confirms we're offline.
-            if isConnectivityError(error) || pathStatus != .satisfied {
+            // Require pathMonitorReady to avoid false-positives at launch before
+            // the monitor has fired its first update.
+            if isConnectivityError(error) || (pathMonitorReady && pathStatus != .satisfied) {
                 claudeError = .networkUnavailable
             }
         }

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
@@ -128,27 +128,13 @@ final class ClaudeLoginWindowController: NSObject {
     }
 
     func show() {
+        // Skip the cookie pre-check here — silentSignInIfPossible() already ran
+        // before signIn() was called, so if we've reached this point the user
+        // genuinely needs to log in. Going straight to showWindow() avoids the
+        // async getAllCookies delay that caused the login window to appear late.
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .default()
-
-        config.websiteDataStore.httpCookieStore.getAllCookies { [weak self] cookies in
-            guard let self else { return }
-
-            let claudeCookies = cookies.filter { $0.domain.contains("claude.ai") }
-            print("[ClaudeAuth] existing cookies: \(claudeCookies.map(\.name))")
-
-            let isLoggedIn = claudeCookies.contains(where: {
-                Self.loginCookies.contains($0.name)
-            })
-
-            if isLoggedIn {
-                for cookie in claudeCookies { HTTPCookieStorage.shared.setCookie(cookie) }
-                Task { @MainActor [weak self] in self?.complete(with: .success(())) }
-                return
-            }
-
-            Task { @MainActor [weak self] in self?.showWindow(config: config) }
-        }
+        showWindow(config: config)
     }
 
     private func showWindow(config: WKWebViewConfiguration) {


### PR DESCRIPTION
## Summary
- Adds `pathMonitorReady` flag to `QuotaViewModel` — network-unavailable banners are now suppressed until `NWPathMonitor` has fired its first update, eliminating the false-positive \"No network connection\" shown on every launch before the monitor settles
- Removes redundant `getAllCookies` pre-check in `ClaudeLoginWindowController.show()` — the login window now appears immediately on tap instead of waiting for an async cookie lookup (~100–200ms delay that made it feel hung)

## Test plan
- [ ] Quit and relaunch the app — confirm no \"No network connection\" banner on startup
- [ ] Tap \"Connect\" for Claude Code — confirm login window appears immediately (no hang)
- [ ] Go offline, relaunch — confirm banner still appears correctly when genuinely offline