### PR TITLE
fix: clear WKWebView data on reinstall, prevent layout shimmy (v1.7.8)

### DIFF
--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -211,14 +211,15 @@ final class QuotaViewModel {
             if e.isAuthError {
                 codexUsage = nil
                 SharedDefaults.clearUsage()
-                // Keychain said authenticated but session is invalid — try silent re-auth once.
-                codexAuthManager.isAuthenticated = false
-                if await codexAuthManager.silentSignInIfPossible() {
+                // Session may have expired — try a forced cookie recheck before clearing
+                // auth state. Avoids a brief "Connect" flash when cookies are still valid
+                // but haven't been synced to URLSession yet.
+                if await codexAuthManager.silentSignInIfPossible(forceRecheck: true) {
                     await refreshCodex()
                     return
                 }
-                // Silent re-auth also failed — session is genuinely gone.
-                // isAuthenticated is already false so the gauge shows "Connect".
+                // Recheck also failed — session is genuinely gone.
+                codexAuthManager.isAuthenticated = false
                 // Don't surface an error banner; the user can reconnect from the gauge.
                 return
             } else if case .networkUnavailable = e, !pathMonitorReady {
@@ -264,14 +265,15 @@ final class QuotaViewModel {
             if e.isAuthError {
                 claudeUsage = nil
                 SharedDefaults.clearClaudeUsage()
-                // Keychain said authenticated but cookies are gone — try silent re-auth once.
-                claudeAuthManager.isAuthenticated = false
-                if await claudeAuthManager.silentSignInIfPossible() {
+                // Session may have expired — try a forced cookie recheck before clearing
+                // auth state. Avoids a brief "Connect" flash when cookies are still valid
+                // but haven't been synced to URLSession yet.
+                if await claudeAuthManager.silentSignInIfPossible(forceRecheck: true) {
                     await refreshClaude()
                     return
                 }
-                // Silent re-auth also failed — session is genuinely gone.
-                // isAuthenticated is already false so the gauge shows "Connect".
+                // Recheck also failed — session is genuinely gone.
+                claudeAuthManager.isAuthenticated = false
                 // Don't surface an error banner; the user can reconnect from the gauge.
                 return
             } else if case .networkUnavailable = e, !pathMonitorReady {

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/AuthManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/AuthManager.swift
@@ -44,17 +44,24 @@ public final class AuthManager: NSObject, ObservableObject {
 
     // MARK: - Fresh-install cleanup
 
-    /// Keychain entries survive app uninstall on macOS, which causes "Not signed in"
-    /// banners on reinstall when the session cookies are gone but the token remains.
-    /// We use a sentinel key to detect a fresh install and wipe stale auth state.
+    /// Keychain entries and WKWebView cookies survive app uninstall on macOS, which causes
+    /// "ghost login" on reinstall — the sign-in button silently reuses stale session data.
+    /// We use a sentinel key to detect a fresh install and wipe everything on first launch.
     private static func clearStateIfFreshInstall() {
         let sentinel = "app.installedAt.v1"
         guard KeychainStore.load(forKey: sentinel) == nil else { return }
-        // First launch after fresh install — clear everything
+        // First launch after fresh install — clear Keychain, SharedDefaults, and WKWebView store
         KeychainStore.delete(forKey: "sessionToken")
         KeychainStore.delete(forKey: "claudeAuthenticated")
         SharedDefaults.clearUsage()
         SharedDefaults.clearClaudeUsage()
+        // WKWebView cookies survive uninstall too. Clear the entire default store so clicking
+        // "Sign in" always shows the real login window rather than auto-completing silently.
+        Task { @MainActor in
+            let store = WKWebsiteDataStore.default()
+            let types = WKWebsiteDataStore.allWebsiteDataTypes()
+            await store.removeData(ofTypes: types, modifiedSince: Date(timeIntervalSince1970: 0))
+        }
         KeychainStore.save("1", forKey: sentinel)
     }
 
@@ -109,9 +116,11 @@ public final class AuthManager: NSObject, ObservableObject {
 
     /// Checks the WKWebView cookie store for an existing ChatGPT session without showing any UI.
     /// If a valid session cookie is found, syncs it and fetches a fresh JWT.
+    /// Pass `forceRecheck: true` to re-verify cookies even when already marked authenticated
+    /// (used during refresh to recover from stale URLSession cookies without a UI flash).
     @discardableResult
-    public func silentSignInIfPossible() async -> Bool {
-        guard !isAuthenticated else { return true }
+    public func silentSignInIfPossible(forceRecheck: Bool = false) async -> Bool {
+        guard !isAuthenticated || forceRecheck else { return true }
         return await withCheckedContinuation { continuation in
             WKWebsiteDataStore.default().httpCookieStore.getAllCookies { [weak self] cookies in
                 guard let self else { continuation.resume(returning: false); return }

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/AuthManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/AuthManager.swift
@@ -48,8 +48,13 @@ public final class AuthManager: NSObject, ObservableObject {
     /// "ghost login" on reinstall — the sign-in button silently reuses stale session data.
     /// We use a sentinel key to detect a fresh install and wipe everything on first launch.
     private static func clearStateIfFreshInstall() {
-        let sentinel = "app.installedAt.v1"
-        guard KeychainStore.load(forKey: sentinel) == nil else { return }
+        // The sentinel lives in UserDefaults.standard — AppZapper (and manual uninstalls)
+        // remove the app's .plist from ~/Library/Preferences, so this reliably resets
+        // on each fresh install. Keychain storage would NOT work here because Keychain
+        // entries survive uninstall and the guard would always short-circuit.
+        let sentinel = "app.installedAt.v2"
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: sentinel) == nil else { return }
         // First launch after fresh install — clear Keychain, SharedDefaults, and WKWebView store
         KeychainStore.delete(forKey: "sessionToken")
         KeychainStore.delete(forKey: "claudeAuthenticated")
@@ -62,7 +67,7 @@ public final class AuthManager: NSObject, ObservableObject {
             let types = WKWebsiteDataStore.allWebsiteDataTypes()
             await store.removeData(ofTypes: types, modifiedSince: Date(timeIntervalSince1970: 0))
         }
-        KeychainStore.save("1", forKey: sentinel)
+        defaults.set(true, forKey: sentinel)
     }
 
     // MARK: - Access Token

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
@@ -55,9 +55,11 @@ public final class ClaudeAuthManager: NSObject, ObservableObject {
 
     /// Checks the WKWebView cookie store for existing Claude session cookies without showing any UI.
     /// If valid cookies are found, syncs them and marks as authenticated.
+    /// Pass `forceRecheck: true` to re-verify cookies even when already marked authenticated
+    /// (used during refresh to recover from stale URLSession cookies without a UI flash).
     @discardableResult
-    public func silentSignInIfPossible() async -> Bool {
-        guard !isAuthenticated else { return true }
+    public func silentSignInIfPossible(forceRecheck: Bool = false) async -> Bool {
+        guard !isAuthenticated || forceRecheck else { return true }
         return await withCheckedContinuation { continuation in
             WKWebsiteDataStore.default().httpCookieStore.getAllCookies { [weak self] cookies in
                 guard let self else { continuation.resume(returning: false); return }

--- a/project.yml
+++ b/project.yml
@@ -14,7 +14,7 @@ options:
 # CURRENT_PROJECT_VERSION = fallback; overridden at build time by git commit count.
 settings:
   base:
-    MARKETING_VERSION: "1.7.7"
+    MARKETING_VERSION: "1.7.8"
     CURRENT_PROJECT_VERSION: "1"
 
 packages:


### PR DESCRIPTION
## Summary

- **Ghost login on reinstall**: WKWebView cookies and Keychain entries both survive AppZapper. The fresh-install sentinel was stored in Keychain (also survives), so the cleanup never ran on reinstall. Moved the sentinel to `UserDefaults.standard` (wiped by AppZapper), and added WKWebView data store clearing alongside the existing Keychain/SharedDefaults wipe.
- **Layout shimmy during refresh**: Setting `isAuthenticated = false` before attempting silent re-auth caused the gauge to briefly flash the "Connect" button. Changed both `refreshCodex()` and `refreshClaude()` to call `silentSignInIfPossible(forceRecheck: true)` first — `isAuthenticated` only goes to false if the cookie recheck also fails.

## Test plan

- [ ] AppZapper the app, reinstall — sign-in buttons should open the real login windows, not auto-login silently
- [ ] With both services connected, trigger refresh (Cmd+R) — no "Connect" button flash
- [ ] Normal sign-in / sign-out flows unaffected