### PR TITLE
fix: manual refresh and post-reboot error suppression

### DIFF
--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -57,6 +57,10 @@ final class QuotaViewModel {
     private var refreshTask: Task<Void, Never>?
     private var authCancellable: AnyCancellable?
     private var claudeAuthCancellable: AnyCancellable?
+    /// Incremented on each manual refresh so the previous task's `defer` doesn't
+    /// clear `isLoading` after the new request has already started.
+    private var codexRefreshGeneration = 0
+    private var claudeRefreshGeneration = 0
 
     /// Tracks whether the last known network path was unsatisfied so we can
     /// detect a transition back online and refresh immediately.
@@ -195,9 +199,10 @@ final class QuotaViewModel {
     func refreshCodex() async {
         if !isCodexAuthenticated { await codexAuthManager.silentSignInIfPossible() }
         guard !isCodexLoading, isCodexAuthenticated else { return }
+        let gen = codexRefreshGeneration
         isCodexLoading = true
         codexError = nil
-        defer { isCodexLoading = false }
+        defer { if codexRefreshGeneration == gen { isCodexLoading = false } }
 
         do {
             let result = try await codexClient.fetchUsage()
@@ -227,6 +232,11 @@ final class QuotaViewModel {
                 // the false-positive "No network connection" flash at launch.
                 logger.info("[CodexRefresh] suppressing networkUnavailable: pathMonitor not ready yet")
                 return
+            } else if case .decodingError = e {
+                // Transient decode failure (e.g. server returned an error page during
+                // post-reboot network init). Let the next auto-refresh recover silently.
+                logger.info("[CodexRefresh] suppressing decodingError — will retry on next cycle")
+                return
             }
             codexError = e
         } catch is CancellationError {
@@ -249,9 +259,10 @@ final class QuotaViewModel {
     func refreshClaude() async {
         if !isClaudeAuthenticated { await claudeAuthManager.silentSignInIfPossible() }
         guard !isClaudeLoading, isClaudeAuthenticated else { return }
+        let gen = claudeRefreshGeneration
         isClaudeLoading = true
         claudeError = nil
-        defer { isClaudeLoading = false }
+        defer { if claudeRefreshGeneration == gen { isClaudeLoading = false } }
 
         do {
             let result = try await claudeClient.fetchUsage()
@@ -280,6 +291,11 @@ final class QuotaViewModel {
                 // Path monitor hasn't settled yet — suppress the banner to avoid
                 // the false-positive "No network connection" flash at launch.
                 logger.info("[ClaudeRefresh] suppressing networkUnavailable: pathMonitor not ready yet")
+                return
+            } else if case .decodingError = e {
+                // Transient decode failure (e.g. server returned an error page during
+                // post-reboot network init). Let the next auto-refresh recover silently.
+                logger.info("[ClaudeRefresh] suppressing decodingError — will retry on next cycle")
                 return
             }
             claudeError = e
@@ -319,6 +335,16 @@ final class QuotaViewModel {
     func stopAutoRefresh() {
         refreshTask?.cancel()
         refreshTask = nil
+    }
+
+    /// User-initiated refresh. Cancels any in-flight auto-refresh and restarts
+    /// immediately, bypassing the `isLoading` guard that blocks concurrent calls.
+    func manualRefresh() {
+        codexRefreshGeneration += 1
+        claudeRefreshGeneration += 1
+        isCodexLoading = false
+        isClaudeLoading = false
+        startAutoRefresh()
     }
 
     // MARK: - Sign In / Out

--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -20,7 +20,7 @@ struct PopoverView: View {
         .frame(width: 340)
         .background(WindowCapture { menuBarWindow = $0 })
         .background {
-            Button("") { Task { await viewModel.refresh() } }
+            Button("") { viewModel.manualRefresh() }
                 .keyboardShortcut("r", modifiers: .command)
                 .hidden()
         }
@@ -104,7 +104,7 @@ struct PopoverView: View {
                     secondaryLabel: "7-day",
                     resetSeconds: u.hourlyResetAfterSeconds,
                     isRefreshing: viewModel.isCodexLoading,
-                    onRefresh: { Task { await viewModel.refreshCodex() } }
+                    onRefresh: { viewModel.manualRefresh() }
                 )
                 .help(codexTooltip(u))
             } else {
@@ -139,7 +139,7 @@ struct PopoverView: View {
                     secondaryLabel: "7-day",
                     resetSeconds: u.resetAfterSeconds,
                     isRefreshing: viewModel.isClaudeLoading,
-                    onRefresh: { Task { await viewModel.refreshClaude() } }
+                    onRefresh: { viewModel.manualRefresh() }
                 )
                 .help(claudeTooltip(u))
             } else {
@@ -391,7 +391,7 @@ struct PopoverView: View {
             } else {
                 Button {
                     dismiss()
-                    Task { await viewModel.refresh() }
+                    viewModel.manualRefresh()
                 } label: {
                     Image(systemName: "arrow.clockwise").font(.caption)
                 }


### PR DESCRIPTION
## Summary

- Manual refresh now interrupts any in-flight background request. Previously, tapping refresh while an auto-refresh was running was a silent no-op due to the `isLoading` guard — most noticeable right after launch when the first refresh was slow
- Added a generation counter so a cancelled task's `defer` can't clear `isLoading` after a new request has already started
- Suppress `decodingError` banner on startup — during post-reboot network initialization, APIs briefly return non-JSON responses; the auto-refresh loop recovers on its own without needing to alarm the user

## Test plan

- [ ] Trigger a refresh, immediately tap the refresh button again — second tap should interrupt and restart (spinner resets)
- [ ] Restart Mac, open app immediately — no error banner should appear even if first fetch fails; should recover within one refresh cycle