### PR TITLE
docs: auth current implementation spec

### DIFF
--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -127,19 +127,28 @@ final class QuotaViewModel {
         codexUsage  = SharedDefaults.loadCachedUsage()
         claudeUsage = SharedDefaults.loadCachedClaudeUsage()
 
-        // Default active service to first authenticated one
-        if !codexAuth.isAuthenticated && claudeAuth.isAuthenticated {
-            activeService = .claude
-        }
-
-        // Bridge ObservableObject → @Observable
+        // Bridge ObservableObject → @Observable.
+        // Also kick off auto-refresh when auth is first restored from Keychain — the
+        // Keychain load is deferred by one run loop tick (to keep the app window first
+        // in front of any OS "allow keychain" dialog), so isAuthenticated is always
+        // false at init time and must be handled reactively here instead.
         authCancellable = codexAuth.$isAuthenticated
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] value in self?.isCodexAuthenticated = value }
+            .sink { [weak self] value in
+                guard let self else { return }
+                isCodexAuthenticated = value
+                if value && refreshTask == nil { startAutoRefresh() }
+            }
 
         claudeAuthCancellable = claudeAuth.$isAuthenticated
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] value in self?.isClaudeAuthenticated = value }
+            .sink { [weak self] value in
+                guard let self else { return }
+                isClaudeAuthenticated = value
+                // Default active service to Claude if that's all that's authenticated
+                if value && !isCodexAuthenticated { activeService = .claude }
+                if value && refreshTask == nil { startAutoRefresh() }
+            }
 
         // Request notification permission on launch
         if settings.notifications.enabled {
@@ -154,20 +163,6 @@ final class QuotaViewModel {
         // is already running by the time silentSignInIfPossible() or syncCookies()
         // is needed, whether or not Claude is currently authenticated.
         Task { await claudeAuthManager.syncCookies() }
-
-        // Kick off refresh on launch. For Claude, sync WKWebView cookies first so
-        // the session is available to URLSession before the first fetch — prevents
-        // the false-positive "Not signed in" banner that appears when the WKWebView
-        // process hasn't finished loading its cookie store yet.
-        if codexAuth.isAuthenticated || claudeAuth.isAuthenticated {
-            Task { [weak self] in
-                guard let self else { return }
-                if claudeAuth.isAuthenticated {
-                    await claudeAuthManager.syncCookies()
-                }
-                startAutoRefresh()
-            }
-        }
     }
 
     // MARK: - Network path monitor

--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -435,10 +435,7 @@ final class QuotaViewModel {
     }
 
     func signOutClaude() {
-        // Set isAuthenticated = false synchronously so the UI updates immediately,
-        // then fire the full async cleanup (Keychain + HTTPCookieStorage + WKWebView).
-        claudeAuthManager.isAuthenticated = false
-        Task { await claudeAuthManager.signOut() }
+        claudeAuthManager.signOut()
         claudeUsage = nil
         SharedDefaults.clearClaudeUsage()
         WidgetCenter.shared.reloadAllTimelines()

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/AuthManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/AuthManager.swift
@@ -38,8 +38,12 @@ public final class AuthManager: NSObject, ObservableObject {
 
     public override init() {
         super.init()
-        Self.clearStateIfFreshInstall()
-        loadSessionFromKeychain()
+        // Defer Keychain access by one run loop tick so the app window appears
+        // before any OS "allow keychain access" dialog is shown to the user.
+        DispatchQueue.main.async { [weak self] in
+            Self.clearStateIfFreshInstall()
+            self?.loadSessionFromKeychain()
+        }
     }
 
     // MARK: - Fresh-install cleanup

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
@@ -31,7 +31,11 @@ public final class ClaudeAuthManager: NSObject, ObservableObject {
 
     public override init() {
         super.init()
-        loadAuthFromKeychain()
+        // Defer Keychain access by one run loop tick so the app window appears
+        // before any OS "allow keychain access" dialog is shown to the user.
+        DispatchQueue.main.async { [weak self] in
+            self?.loadAuthFromKeychain()
+        }
     }
 
     // MARK: - Sign In

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
@@ -74,9 +74,10 @@ public final class ClaudeAuthManager: NSObject, ObservableObject {
     @discardableResult
     public func silentSignInIfPossible(forceRecheck: Bool = false) async -> Bool {
         guard !isAuthenticated || forceRecheck else { return true }
-        // After an explicit sign-out, block silent re-auth from treating stale
-        // WKWebView cookies as valid. forceRecheck (session recovery) still passes.
-        guard forceRecheck || !UserDefaults.standard.bool(forKey: Self.explicitlySignedOutKey) else {
+        // explicitlySignedOut always blocks silent re-auth — even when forceRecheck is true.
+        // forceRecheck means "re-verify cookies even if already marked authenticated"
+        // (session recovery after an app update). It does NOT mean "override an explicit sign-out."
+        guard !UserDefaults.standard.bool(forKey: Self.explicitlySignedOutKey) else {
             return false
         }
         return await withCheckedContinuation { continuation in

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
@@ -107,12 +107,13 @@ public final class ClaudeAuthManager: NSObject, ObservableObject {
 
     // MARK: - Sign Out
 
-    /// Clears all auth state synchronously.
+    /// Clears all auth state.
     ///
-    /// WKWebView cookies are intentionally NOT cleared here. The stale WK cookies are
-    /// harmless until the next login attempt: silentSignInIfPossible() is blocked by the
-    /// explicitlySignedOut flag, and signIn() clears the WK store before opening the
-    /// login window — so the ClaudeCookieObserver can never see stale cookies.
+    /// The explicitlySignedOut flag is set synchronously — this is the primary guard
+    /// that blocks silentSignInIfPossible() immediately. WKWebView cookies are cleared
+    /// asynchronously (best-effort) so they don't persist across app restarts. signIn()
+    /// also clears WK cookies before opening the login window as a belt-and-suspenders
+    /// safety net in case the flag is ever absent from UserDefaults.
     public func signOut() {
         isAuthenticated = false
         KeychainStore.delete(forKey: "claudeAuthenticated")
@@ -123,6 +124,9 @@ public final class ClaudeAuthManager: NSObject, ObservableObject {
         for cookie in HTTPCookieStorage.shared.cookies ?? [] where cookie.domain.contains("claude.ai") {
             HTTPCookieStorage.shared.deleteCookie(cookie)
         }
+        // Clear WKWebView cookies asynchronously — best-effort so stale cookies
+        // don't persist to disk and survive app restarts.
+        Task { await clearWKWebViewCookies() }
     }
 
     // MARK: - Cookie Sync

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
@@ -37,6 +37,14 @@ public final class ClaudeAuthManager: NSObject, ObservableObject {
     // MARK: - Sign In
 
     public func signIn() async throws {
+        // Clear the WKWebView cookie store BEFORE opening the login window.
+        // ClaudeCookieObserver is registered with the WK store inside showWindow(),
+        // so if stale session cookies still exist at that moment the observer fires
+        // immediately and the window closes before the user can log in.
+        // Clearing here — synchronously from the caller's perspective — guarantees
+        // the store is empty when the observer is added, eliminating the race entirely.
+        await clearWKWebViewCookies()
+
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             let controller = ClaudeLoginWindowController { [weak self] result in
                 Task { @MainActor [weak self] in
@@ -94,20 +102,30 @@ public final class ClaudeAuthManager: NSObject, ObservableObject {
 
     // MARK: - Sign Out
 
-    /// Clears all auth state and waits for WKWebView cookie deletion to complete
-    /// before returning. Callers must await this to prevent silentSignInIfPossible
-    /// from racing and finding stale cookies immediately after sign-out.
-    public func signOut() async {
+    /// Clears all auth state synchronously.
+    ///
+    /// WKWebView cookies are intentionally NOT cleared here. The stale WK cookies are
+    /// harmless until the next login attempt: silentSignInIfPossible() is blocked by the
+    /// explicitlySignedOut flag, and signIn() clears the WK store before opening the
+    /// login window — so the ClaudeCookieObserver can never see stale cookies.
+    public func signOut() {
         isAuthenticated = false
         KeychainStore.delete(forKey: "claudeAuthenticated")
-        // Set synchronously — blocks silentSignInIfPossible immediately, even
-        // before the async WKWebView deletion completes.
+        // Set synchronously — blocks silentSignInIfPossible immediately.
         UserDefaults.standard.set(true, forKey: Self.explicitlySignedOutKey)
-        // Delete from HTTPCookieStorage synchronously — no race possible.
+        // Clear URLSession cookies synchronously.
         for cookie in HTTPCookieStorage.shared.cookies ?? [] where cookie.domain.contains("claude.ai") {
             HTTPCookieStorage.shared.deleteCookie(cookie)
         }
-        // Await WKWebView cookie deletion so callers don't race with it.
+    }
+
+    // MARK: - Cookie Sync
+
+    /// Deletes all claude.ai cookies from the WKWebView default data store and waits
+    /// for deletion to complete. Called at the start of signIn() so the login window
+    /// opens with a clean store — preventing ClaudeCookieObserver from firing on stale
+    /// session cookies from a previous login.
+    private func clearWKWebViewCookies() async {
         await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
             WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
                 let claudeCookies = cookies.filter { $0.domain.contains("claude.ai") }
@@ -121,8 +139,6 @@ public final class ClaudeAuthManager: NSObject, ObservableObject {
             }
         }
     }
-
-    // MARK: - Cookie Sync
 
     public func syncCookies() async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
@@ -78,13 +78,17 @@ public final class ClaudeAuthManager: NSObject, ObservableObject {
         // forceRecheck means "re-verify cookies even if already marked authenticated"
         // (session recovery after an app update). It does NOT mean "override an explicit sign-out."
         guard !UserDefaults.standard.bool(forKey: Self.explicitlySignedOutKey) else {
+            logger.info("[ClaudeAuth] silentSignIn blocked — explicitlySignedOut flag is set (forceRecheck=\(forceRecheck))")
             return false
         }
         return await withCheckedContinuation { continuation in
             WKWebsiteDataStore.default().httpCookieStore.getAllCookies { [weak self] cookies in
                 guard let self else { continuation.resume(returning: false); return }
                 let claudeCookies = cookies.filter { $0.domain.contains("claude.ai") }
+                let cookieNames = claudeCookies.map(\.name)
+                self.logger.info("[ClaudeAuth] silentSignIn checking \(claudeCookies.count) cookies: \(cookieNames)")
                 guard claudeCookies.contains(where: { Self.loginCookies.contains($0.name) }) else {
+                    self.logger.info("[ClaudeAuth] silentSignIn — no session cookies found, returning false")
                     continuation.resume(returning: false)
                     return
                 }
@@ -114,6 +118,7 @@ public final class ClaudeAuthManager: NSObject, ObservableObject {
         KeychainStore.delete(forKey: "claudeAuthenticated")
         // Set synchronously — blocks silentSignInIfPossible immediately.
         UserDefaults.standard.set(true, forKey: Self.explicitlySignedOutKey)
+        logger.info("[ClaudeAuth] signOut — explicitlySignedOut flag SET")
         // Clear URLSession cookies synchronously.
         for cookie in HTTPCookieStorage.shared.cookies ?? [] where cookie.domain.contains("claude.ai") {
             HTTPCookieStorage.shared.deleteCookie(cookie)

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeClient.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeClient.swift
@@ -88,7 +88,8 @@ public actor ClaudeClient {
             let raw = try Self.decoder.decode(ClaudeUsageResponse.self, from: data)
             return buildUsage(from: raw)
         } catch {
-            print("[ClaudeClient] decode error: \(error)")
+            let preview = String(data: data.prefix(800), encoding: .utf8) ?? "<non-utf8>"
+            print("[ClaudeClient] decode error: \(error)\nResponse body: \(preview)")
             throw NetworkError.decodingError(underlying: error)
         }
     }
@@ -204,7 +205,7 @@ private struct ClaudeUsageResponse: Decodable {
 
     struct WindowBucket: Decodable {
         let utilization: Double
-        let resetsAt: Date
+        let resetsAt: Date?
     }
 
     struct ExtraUsageBucket: Decodable {

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Storage/KeychainStore.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Storage/KeychainStore.swift
@@ -4,12 +4,20 @@ import Security
 public enum KeychainStore {
     private static let service = "com.niederme.AIQuota"
 
+    // kSecUseDataProtectionKeychain = true stores items in the modern per-app data
+    // protection keychain rather than the legacy login keychain. The login keychain
+    // uses ACL-based access control and shows a "password required" dialog whenever
+    // the app's code signature changes (every Xcode build, every update). The data
+    // protection keychain is tied to the app's bundle ID and never prompts the user.
+    // Available on macOS 10.15+.
+
     public static func save(_ value: String, forKey key: String) {
         guard let data = value.data(using: .utf8) else { return }
         let query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
             kSecAttrAccount: key,
+            kSecUseDataProtectionKeychain: true,
         ]
         SecItemDelete(query as CFDictionary)
         let attributes: [CFString: Any] = [
@@ -18,6 +26,7 @@ public enum KeychainStore {
             kSecAttrAccount: key,
             kSecValueData: data,
             kSecAttrAccessible: kSecAttrAccessibleAfterFirstUnlock,
+            kSecUseDataProtectionKeychain: true,
         ]
         SecItemAdd(attributes as CFDictionary, nil)
     }
@@ -29,6 +38,7 @@ public enum KeychainStore {
             kSecAttrAccount: key,
             kSecReturnData: true,
             kSecMatchLimit: kSecMatchLimitOne,
+            kSecUseDataProtectionKeychain: true,
         ]
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
@@ -44,6 +54,7 @@ public enum KeychainStore {
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: service,
             kSecAttrAccount: key,
+            kSecUseDataProtectionKeychain: true,
         ]
         SecItemDelete(query as CFDictionary)
     }

--- a/docs/auth-coordinator-spec.md
+++ b/docs/auth-coordinator-spec.md
@@ -1,0 +1,282 @@
+# Auth Coordinator Spec
+
+## Motivation
+
+The current auth implementation spreads state across WebKit cookies, URLSession cookies,
+Keychain, UserDefaults, and view-model booleans. Reset, sign-out, and silent re-auth race
+each other because multiple call sites infer app auth state by reading WebKit directly.
+
+The root failure: WebKit is treated as a live oracle for app state rather than as external
+I/O to be read during specific, controlled transitions.
+
+## Framing rule
+
+WebKit is the source of session truth, but it is not the source of app state truth.
+
+- WebKit may be read only during coordinator-owned transitions.
+- The result of any WebKit read must be recorded in coordinator state before the transition
+  completes.
+- No other code path may read or mutate WebKit, Keychain, or URLSession auth state.
+
+---
+
+## Architecture
+
+Each service gets one `AuthCoordinator` actor. One `AppResetCoordinator` actor handles
+cross-service reset.
+
+### Responsibilities
+
+**`AuthCoordinator` (per service)**
+- Owns auth intent, in-process auth state, and all WebKit/Keychain/UserDefaults interaction
+  for its service.
+- Is the only code that reads or clears service-specific WebKit cookies.
+- Provides a narrow public API; never exposes cookies, Keychain values, WebKit handles, or
+  ad hoc auth booleans.
+
+**`QuotaViewModel`**
+- Owns refresh cadence, loading UI, widgets, onboarding, and other product behavior.
+- Observes coordinator state; does not probe cookies, clear cookies, or decide whether silent
+  auth is allowed.
+- Starts refresh only when coordinator state is `authenticated`.
+- On a 401, asks the coordinator to run `revalidateSessionAfterAuthFailure()` and uses the
+  returned bool to decide whether to retry.
+
+**`AppResetCoordinator`**
+- Owns cross-service reset orchestration.
+- Awaits both service coordinators reaching stable signed-out state before any product state
+  is cleared.
+
+---
+
+## Persisted state
+
+Persist only:
+- `signedOutByUser` (per service)
+
+Do not persist as authoritative:
+- `authenticated`
+- Cookie-derived session mirrors
+- "Logged in" booleans in Keychain or UserDefaults
+
+---
+
+## Auth states
+
+| State | Meaning |
+|---|---|
+| `unknown` | Process has not yet completed bootstrap evaluation. Startup-only; never re-entered. |
+| `restoringSession` | Bootstrap probe is currently running. |
+| `authenticated` | A coordinator transition confirmed a valid WebKit-backed session. |
+| `unauthenticated` | Probe or revalidation found no usable session; user may sign in. |
+| `signedOutByUser` | Explicit user intent blocks silent re-auth until a new explicit sign-in. |
+| `signingIn` | Interactive login flow is in progress. |
+| `signingOut` | Teardown is in progress following an explicit sign-out. |
+| `resetting` | Teardown is in progress following a reset request. |
+
+---
+
+## Legal transitions
+
+Any transition not listed here is illegal.
+
+| From | To | Trigger | Notes |
+|---|---|---|---|
+| `unknown` | `restoringSession` | bootstrap starts | Only at process start when persisted `signedOutByUser` is absent |
+| `restoringSession` | `authenticated` | probe found valid session | Probe reads WebKit once, records result |
+| `restoringSession` | `unauthenticated` | probe found no session | Normal cold-start unauthenticated result |
+| `restoringSession` | `unauthenticated` | probe timed out or failed | Pessimistic resolution |
+| `unauthenticated` | `signingIn` | `signIn()` | Legal |
+| `signedOutByUser` | `signingIn` | `signIn()` | Only legal exit from `signedOutByUser` |
+| `signingIn` | `authenticated` | login succeeded | Also clears persisted `signedOutByUser` |
+| `signingIn` | `unauthenticated` | login failed or user cancelled | No silent fallback |
+| `authenticated` | `signingOut` | `signOut()` | Legal |
+| `signingOut` | `signedOutByUser` | teardown verified | Intended success path |
+| `authenticated` | `unauthenticated` | `revalidateSessionAfterAuthFailure()` found no valid session, or timed out | Coordinator publishes `unauthenticated` before returning `false` |
+| `authenticated` | `resetting` | `reset()` | Legal |
+| `unauthenticated` | `resetting` | `reset()` | Legal |
+| `signedOutByUser` | `resetting` | `reset()` | Legal |
+| `signingOut` | `signedOutByUser` | teardown timed out | Warning path, not undefined state |
+| `resetting` | `signedOutByUser` | teardown verified | Intended success path |
+| `resetting` | `signedOutByUser` | teardown timed out | Warning path, not undefined state |
+
+### Edge rules
+
+- `signIn()` from `authenticated`: throws typed `invalidTransition`; not a re-login path.
+- `signOut()` from `unauthenticated`: explicit no-op.
+- `signOut()` from `signedOutByUser`: explicit no-op.
+- `reset()` called during `signingIn` or `signingOut`: waits for the in-flight transition to
+  settle, then runs.
+- `reset()` called during `resetting`: waits for the in-flight reset to finish.
+
+---
+
+## Public API
+
+```
+var state: AuthState { get }
+func signIn() async throws
+func signOut() async
+func revalidateSessionAfterAuthFailure() async -> Bool
+func reset() async
+```
+
+### Illegal transition handling
+
+| Method | Illegal-state behavior |
+|---|---|
+| `signIn()` | Throws `invalidTransition` from any state other than `unauthenticated` or `signedOutByUser` |
+| `signOut()` | No-op from `unauthenticated` and `signedOutByUser`; throws `invalidTransition` from transient states |
+| `revalidateSessionAfterAuthFailure()` | Returns `false` from any non-`authenticated` state; no transition |
+| `reset()` | Never throws; waits for any in-flight transition, then proceeds |
+
+---
+
+## Transition behavior
+
+### Bootstrap
+
+**Launch rule:** if persisted `signedOutByUser` exists, coordinator starts there immediately
+and skips bootstrap probing. Otherwise:
+
+1. Publish `restoringSession`.
+2. Perform exactly one bounded WebKit probe.
+3. If probe confirms a valid session, publish `authenticated`.
+4. If probe finds no session, publish `unauthenticated`.
+5. If probe times out or errors, publish `unauthenticated` (pessimistic resolution).
+
+Notes:
+- No refresh may begin while state is `unknown` or `restoringSession`.
+- No `authenticated` mirror is persisted from this result.
+
+---
+
+### `signIn()`
+
+Legal from: `unauthenticated`, `signedOutByUser`
+
+1. Publish `signingIn`.
+2. If stale WebKit cookies need to be cleared before the interactive flow, that cleanup
+   happens here, inside this transition.
+3. Run the interactive login flow (WKWebView login window).
+4. Read required WebKit session artifacts exactly once as part of this transition.
+5. If session is valid, clear persisted `signedOutByUser`, record artifacts in coordinator
+   memory, and publish `authenticated`.
+6. If user cancels or login fails, publish `unauthenticated`.
+
+---
+
+### `signOut()`
+
+Legal from: `authenticated`
+No-op from: `unauthenticated`, `signedOutByUser`
+
+1. Publish `signingOut`.
+2. Persist `signedOutByUser` immediately — this is the primary guard; it takes effect before
+   any async teardown begins.
+3. Clear in-memory auth state and relevant URLSession state.
+4. Clear service-specific WebKit cookies/data.
+5. Re-read WebKit and verify auth artifacts are gone.
+6. On success, publish `signedOutByUser`.
+7. On verification timeout, still publish `signedOutByUser` and record a warning.
+
+---
+
+### `revalidateSessionAfterAuthFailure()`
+
+Legal from: `authenticated`
+
+1. Confirm current state is `authenticated`; otherwise return `false` immediately.
+2. Perform one bounded WebKit revalidation probe.
+3. If probe confirms a valid session, refresh coordinator-owned in-memory auth context as
+   needed, remain in `authenticated`, and return `true`.
+4. If probe finds no session, publish `unauthenticated` and return `false`.
+5. If probe times out or errors, publish `unauthenticated` and return `false`.
+
+Notes:
+- This is the only "silent recovery after 401" path.
+- The ViewModel receives only a retry decision, not raw auth details.
+
+---
+
+### `reset()`
+
+Legal from: `authenticated`, `unauthenticated`, `signedOutByUser`
+Concurrency: if `signingIn`, `signingOut`, or `resetting` is in progress, waits for that
+transition to settle before proceeding.
+
+1. Publish `resetting`.
+2. Persist `signedOutByUser` immediately.
+3. Clear coordinator-owned in-memory auth state.
+4. Clear service-specific URLSession cookies/storage.
+5. Clear service-specific WebKit cookies/storage.
+6. Re-read WebKit and verify relevant auth artifacts are absent.
+7. On success, publish `signedOutByUser`.
+8. On verification timeout, still publish `signedOutByUser` and record a warning.
+
+**Reset failure semantics:** verification timeout does not leave the coordinator in limbo.
+`signedOutByUser` has already been persisted, so silent re-auth remains blocked on the next
+launch regardless of whether WebKit cleanup could be fully verified.
+
+---
+
+## App-level reset
+
+`AppResetCoordinator` is a separate actor called by `QuotaViewModel`.
+
+1. Stop the ViewModel refresh loop, cancel any in-flight refresh work, and await actual
+   completion of those tasks — not just cancellation requests — before proceeding.
+2. Request `reset()` on both service coordinators concurrently.
+3. Await both to reach terminal stable state (`signedOutByUser`).
+4. Collect any warnings (e.g. teardown verification timeouts).
+5. Only after both auth resets complete: clear product-level cached usage, settings,
+   onboarding flags, and related UI state.
+6. Notify `QuotaViewModel` that reset is complete.
+7. `QuotaViewModel` presents onboarding / signed-out UI.
+
+Auth reset and product reset are sequenced, not interleaved.
+
+---
+
+## Client auth context boundary
+
+`ClaudeClient` and `OpenAIClient`:
+- Do not read WebKit directly.
+- Do not manipulate `HTTPCookieStorage.shared` directly.
+- Do not infer auth state.
+- Do not manage their own auth recovery logic.
+- Consume session artifacts provided by coordinator-owned state established during
+  transitions.
+
+Specific implications:
+- `ClaudeClient` does not discover `lastActiveOrg` from cookies at fetch time. The `orgId`
+  and any other required request context is captured by the coordinator during bootstrap,
+  sign-in, or revalidation.
+- `OpenAIClient` receives a coordinator-provided auth context or token. On an auth failure,
+  it reports the error and the caller asks the coordinator to run
+  `revalidateSessionAfterAuthFailure()`.
+
+Deferred to implementation: the exact shape of the coordinator-to-client interface (value-type
+request context, auth provider protocol, or coordinator-owned transport).
+
+---
+
+## UI / presentation notes
+
+- During `restoringSession`, show a short-lived, clearly transitional restoring state in the
+  popover auth area — not a full-app spinner.
+- Cached usage from `SharedDefaults` may still render during `restoringSession`.
+- Empty gauges are acceptable if no cached usage exists; this state is brief.
+- No refresh starts until coordinator publishes `authenticated`.
+- No auth UI claims the user is signed in before bootstrap resolves.
+- After an explicit sign-out or reset, do not show `restoringSession`; go directly to
+  signed-out UI because user intent is already known.
+
+---
+
+## Deferred
+
+- State observation mechanism: choice between `AsyncStream`, an `@MainActor`-isolated
+  observable wrapper, or another publishing mechanism is deferred to implementation.
+- Exact coordinator-to-client interface shape is deferred to implementation.
+- Concrete bootstrap and teardown verification timeout values are deferred to implementation.

--- a/docs/auth-current-implementation.md
+++ b/docs/auth-current-implementation.md
@@ -1,0 +1,99 @@
+# AIQuota Auth — Current Implementation
+
+## Storage layer
+
+| Store | Key | What's stored |
+|---|---|---|
+| Keychain (data-protection) | `claudeAuthenticated` | String `"true"` — a flag, not the cookies |
+| Keychain (data-protection) | `sessionToken` | Raw value of `__Secure-next-auth.session-token` cookie |
+| `UserDefaults.standard` | `claude.explicitlySignedOut` | Bool — blocks silent re-auth after explicit sign-out |
+| `UserDefaults.standard` | `app.installedAt.v2` | Sentinel — absent means fresh install |
+| `WKWebsiteDataStore.default()` | — | Actual claude.ai session cookies (persisted by WebKit) |
+| `HTTPCookieStorage.shared` | — | URLSession cookie jar; synced from WKWebView on demand |
+| In-memory (`AuthManager`) | `cachedAccessToken`, `tokenExpiresAt` | Codex JWT cache |
+
+**Key observation:** Keychain for Claude stores only a boolean flag. The actual session cookies live in `WKWebsiteDataStore.default()`.
+
+---
+
+## Claude auth (`ClaudeAuthManager`)
+
+### Initialization
+
+Keychain access is deferred by one run loop tick (so the app window appears before any OS keychain dialog). `loadAuthFromKeychain()` sets `isAuthenticated = true` if `claudeAuthenticated` exists in Keychain. No cookies are read at init.
+
+### `signIn()`
+
+1. Awaits `clearWKWebViewCookies()` — deletes all claude.ai cookies from `WKWebsiteDataStore.default()` and waits for completion before proceeding. This prevents the cookie observer from firing on stale cookies the moment the login window opens.
+2. Opens `ClaudeLoginWindowController`, which shows an NSWindow containing a WKWebView loaded to `https://claude.ai/login`.
+3. Two detection mechanisms run simultaneously:
+   - **Cookie observer** (`ClaudeCookieObserver`): fires on any cookie change → checks for `lastActiveOrg`, `sessionKey`, or `routingHint` → if found, syncs all claude.ai cookies to `HTTPCookieStorage.shared` and completes.
+   - **1-second polling timer**: checks JS `document.cookie` (non-HttpOnly cookies) and then the WKWebView store (HttpOnly cookies) — if login cookies found, syncs and completes.
+4. On success: saves `"true"` to Keychain `claudeAuthenticated`, removes `explicitlySignedOut` flag, sets `isAuthenticated = true`, closes window.
+5. On window close without completion: throws `NetworkError.notAuthenticated`.
+
+### `silentSignInIfPossible(forceRecheck:)`
+
+- If `explicitlySignedOut` UserDefaults flag is set → returns `false` immediately. This flag blocks silent re-auth even when `forceRecheck: true`.
+- Otherwise: reads `WKWebsiteDataStore.default().httpCookieStore.getAllCookies`.
+- If any login cookie found for claude.ai: copies all cookies to `HTTPCookieStorage.shared`, saves Keychain flag, removes `explicitlySignedOut`, sets `isAuthenticated = true`, returns `true`.
+- Otherwise returns `false`.
+
+### `signOut()`
+
+1. Sets `isAuthenticated = false`.
+2. Deletes Keychain `claudeAuthenticated`.
+3. Sets `UserDefaults.standard["claude.explicitlySignedOut"] = true` — synchronous.
+4. Clears claude.ai cookies from `HTTPCookieStorage.shared` — synchronous.
+5. Fires `Task { await clearWKWebViewCookies() }` — async, not awaited (fire-and-forget).
+
+### `syncCookies()`
+
+Copies all claude.ai cookies from `WKWebsiteDataStore.default()` → `HTTPCookieStorage.shared`. Called at the start of every `ClaudeClient.fetchUsage()`.
+
+### API calls
+
+`ClaudeClient.fetchUsage()` calls `syncCookies()`, reads `lastActiveOrg` from `HTTPCookieStorage.shared` to build the URL `/api/organizations/{orgId}/usage`. Auth is entirely cookie-based — no Bearer token. 401/403 → `NetworkError.notAuthenticated`.
+
+---
+
+## Codex auth (`AuthManager`)
+
+### Initialization
+
+Deferred by one run loop tick. `clearStateIfFreshInstall()` runs first: if `app.installedAt.v2` is absent from UserDefaults, clears Keychain entries and the entire `WKWebsiteDataStore.default()`, then sets the sentinel. `loadSessionFromKeychain()` sets `isAuthenticated = true` if `sessionToken` exists.
+
+### `signIn()`
+
+1. Creates `LoginWindowController`.
+2. `show()` immediately checks `WKWebsiteDataStore.default()` for an existing `__Secure-next-auth.session-token` — if found, completes immediately without showing any window.
+3. If not found, opens NSWindow with WKWebView loaded to `https://chatgpt.com`.
+4. Detection via:
+   - **Cookie observer** (`CookieObserver`): fires on any change → checks for `__Secure-next-auth.session-token` → completes with token value.
+   - **`WKNavigationDelegate.didFinish()`**: on each page load, checks URL and cookies. If on `/api/auth/session`, reads JWT from page body via JS. If appears logged in but no session cookie, navigates to `/api/auth/session` to extract it.
+5. On success: saves token value to Keychain `sessionToken`, calls `refreshAccessToken()` to get JWT, sets `isAuthenticated = true`.
+
+### `silentSignInIfPossible(forceRecheck:)`
+
+Reads `WKWebsiteDataStore.default()`. If `__Secure-next-auth.session-token` found, syncs cookies to `HTTPCookieStorage.shared`, saves to Keychain, calls `refreshAccessToken()`. No `explicitlySignedOut` guard (unlike Claude).
+
+### JWT refresh (`accessToken` / `refreshAccessToken()`)
+
+- `accessToken` computed property checks in-memory cache; if missing or within 60s of expiry, calls `refreshAccessToken()`.
+- `refreshAccessToken()`: calls `syncWebKitCookies()` first (WKWebView → HTTPCookieStorage), then GET `https://chatgpt.com/api/auth/session`, caches the returned JWT and expiry in memory.
+- On 401 or empty response: deletes Keychain `sessionToken`, sets `isAuthenticated = false`.
+
+### `signOut()`
+
+Clears in-memory JWT cache, deletes Keychain `sessionToken`, clears chatgpt.com/openai.com cookies from both `WKWebsiteDataStore.default()` and `HTTPCookieStorage.shared`. No `explicitlySignedOut` flag.
+
+---
+
+## QuotaViewModel — auth orchestration
+
+- Holds both auth managers, observes `$isAuthenticated` via Combine. When either transitions to `true`, starts auto-refresh if not already running.
+- `signInClaude()`: calls `silentSignInIfPossible()` first; if that returns `false`, calls `claudeAuthManager.signIn()`.
+- `signIn()` (Codex): directly calls `codexAuthManager.signIn()`.
+- `refreshClaude()`: on 401 → calls `silentSignInIfPossible(forceRecheck: true)` → if succeeds, retries fetch once; if fails, sets `claudeAuthManager.isAuthenticated = false`.
+- `refreshCodex()`: same pattern for Codex.
+- `resetToNewUser()`: calls `signOut()` + `signOutClaude()`, resets settings and onboarding flags.


### PR DESCRIPTION
## Summary

- Documents the current auth implementation for Claude and Codex as-is
- Covers storage layer, sign-in flows, silent re-auth, sign-out, and QuotaViewModel orchestration
- Written as a reference/review document, no code changes

## Purpose

Taking a step back to document how auth currently works before deciding on any fixes or rewrites. Please annotate/comment directly on the file in this PR.