### PR TITLE
fix: replace legacy SF symbols with logo assets in widget empty state

### DIFF
--- a/AIQuotaWidget/Views/WidgetMediumView.swift
+++ b/AIQuotaWidget/Views/WidgetMediumView.swift
@@ -40,7 +40,7 @@ struct WidgetMediumView: View {
                     size: 80
                 )
             } else {
-                emptySlot(icon: "brain.fill", label: "Codex")
+                emptySlot(icon: "logo-openai", label: "Codex")
             }
 
         case .claude:
@@ -57,15 +57,17 @@ struct WidgetMediumView: View {
                     size: 80
                 )
             } else {
-                emptySlot(icon: "sparkles", label: "Claude Code")
+                emptySlot(icon: "logo-claude", label: "Claude Code")
             }
         }
     }
 
     private func emptySlot(icon: String, label: String) -> some View {
         VStack(spacing: 6) {
-            Image(systemName: icon)
-                .font(.title2)
+            Image(icon)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 28, height: 28)
                 .foregroundStyle(WidgetGaugeView.accent.opacity(0.3))
             Text(label).font(.caption.bold()).foregroundStyle(.secondary)
             Text("Sign in to AIQuota").font(.system(size: 9)).foregroundStyle(.tertiary)


### PR DESCRIPTION
## Summary
- The medium widget's empty/unauthenticated state was showing `brain.fill` (Codex) and `sparkles` (Claude Code) SF symbols — legacy icons from an earlier pass
- Replaced with `logo-openai` and `logo-claude` custom image assets, matching what the populated state already uses
- Updated `emptySlot` to use `Image()` with `resizable`/`scaledToFit` sizing instead of `Image(systemName:)`

## Test plan
- [ ] Verify widget empty state shows correct service logos (not brain/sparkle SF symbols)
- [ ] Confirm tint color still applies at reduced opacity in empty state