### PR TITLE
fix: trigger onboarding from PopoverView on first open

### DIFF
--- a/AIQuota/AIQuotaApp.swift
+++ b/AIQuota/AIQuotaApp.swift
@@ -39,7 +39,6 @@ struct AIQuotaApp: App {
                 isLoading: viewModel.isLoading,
                 worstPercent: menuBarWorstPercent
             )
-            .onboardingLauncher(viewModel: viewModel)
         }
         .menuBarExtraStyle(.window)
 
@@ -141,24 +140,3 @@ private struct WindowVibrancyInstaller: NSViewRepresentable {
     func updateNSView(_ nsView: NSView, context: Context) {}
 }
 
-// MARK: - Onboarding launcher modifier
-
-private struct OnboardingLauncherModifier: ViewModifier {
-    @Environment(\.openWindow) private var openWindow
-    let viewModel: QuotaViewModel
-
-    func body(content: Content) -> some View {
-        content.task {
-            if viewModel.shouldShowOnboarding {
-                viewModel.markOnboardingTriggered()
-                openWindow(id: "onboarding")
-            }
-        }
-    }
-}
-
-private extension View {
-    func onboardingLauncher(viewModel: QuotaViewModel) -> some View {
-        modifier(OnboardingLauncherModifier(viewModel: viewModel))
-    }
-}

--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -4,6 +4,7 @@ import AIQuotaKit
 struct PopoverView: View {
     @Environment(QuotaViewModel.self) private var viewModel
     @Environment(\.openSettings) private var openSettings
+    @Environment(\.openWindow) private var openWindow
 
     /// Captured reference to the MenuBarExtra NSWindow so we can re-show it
     /// after Settings opens (which steals key focus and causes the window to close).
@@ -27,6 +28,11 @@ struct PopoverView: View {
                 .hidden()
         }
         .task {
+            if viewModel.shouldShowOnboarding {
+                viewModel.markOnboardingTriggered()
+                NSApp.activate(ignoringOtherApps: true)
+                openWindow(id: "onboarding")
+            }
             if viewModel.usage == nil && viewModel.claudeUsage == nil {
                 await viewModel.refresh()
             }

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Auth/ClaudeAuthCoordinator.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Auth/ClaudeAuthCoordinator.swift
@@ -26,7 +26,8 @@ public actor ClaudeAuthCoordinator {
 
     // MARK: Persistence keys
 
-    private static let signedOutKey = "claude.signedOutByUser"
+    private static let signedOutKey    = "claude.signedOutByUser"
+    private static let freshInstallKey = "app.installedAt.v2"  // shared with CodexAuthCoordinator
 
     // MARK: State
 
@@ -86,6 +87,8 @@ public actor ClaudeAuthCoordinator {
     public func bootstrap() async {
         guard state == .unknown else { return }
 
+        await clearStateIfFreshInstall()
+
         if UserDefaults.standard.bool(forKey: Self.signedOutKey) {
             transition(to: .signedOutByUser)
             return
@@ -102,6 +105,23 @@ public actor ClaudeAuthCoordinator {
         case .notFound, .none:
             transition(to: .unauthenticated)
         }
+    }
+
+    private func clearStateIfFreshInstall() async {
+        let sentinel = Self.freshInstallKey
+        guard UserDefaults.standard.object(forKey: sentinel) == nil else { return }
+        SharedDefaults.clearUsage()
+        SharedDefaults.clearClaudeUsage()
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            Task { @MainActor in
+                let store = WKWebsiteDataStore.default()
+                let types = WKWebsiteDataStore.allWebsiteDataTypes()
+                store.removeData(ofTypes: types, modifiedSince: Date(timeIntervalSince1970: 0)) {
+                    cont.resume()
+                }
+            }
+        }
+        UserDefaults.standard.set(true, forKey: sentinel)
     }
 
     // MARK: - signIn()


### PR DESCRIPTION
## Summary

- `openWindow` silently fails when called from a `MenuBarExtra` label's `.task` at app launch — the app isn't activated yet at that point
- Moves the onboarding trigger into `PopoverView.task`, which fires when the user first clicks the menu bar icon (app is active, `openWindow` works)
- Removes the now-dead `OnboardingLauncherModifier` from `AIQuotaApp`