### PR TITLE
fix: use onAppear for onboarding trigger

### DIFF
--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -27,12 +27,14 @@ struct PopoverView: View {
                 .keyboardShortcut("r", modifiers: .command)
                 .hidden()
         }
-        .task {
+        .onAppear {
             if viewModel.shouldShowOnboarding {
                 viewModel.markOnboardingTriggered()
                 NSApp.activate(ignoringOtherApps: true)
                 openWindow(id: "onboarding")
             }
+        }
+        .task {
             if viewModel.usage == nil && viewModel.claudeUsage == nil {
                 await viewModel.refresh()
             }


### PR DESCRIPTION
openWindow called from inside a .task async context doesn't reliably open the window. onAppear fires synchronously on the main thread when the popover first appears, giving openWindow the correct execution context.