### PR TITLE
fix: disable onboarding Sign In buttons while bootstrap is restoring

### DIFF
--- a/AIQuota/Views/Onboarding/Steps/ServicesStepView.swift
+++ b/AIQuota/Views/Onboarding/Steps/ServicesStepView.swift
@@ -25,6 +25,7 @@ struct ServicesStepView: View {
                     name: "Codex",
                     subtitle: "ChatGPT / OpenAI",
                     isAuthenticated: viewModel.isCodexAuthenticated,
+                    isRestoring: viewModel.isRestoringSession,
                     onSignIn: { Task { await viewModel.signIn() } }
                 )
 
@@ -33,6 +34,7 @@ struct ServicesStepView: View {
                     name: "Claude Code",
                     subtitle: "Anthropic / claude.ai",
                     isAuthenticated: viewModel.isClaudeAuthenticated,
+                    isRestoring: viewModel.isRestoringSession,
                     onSignIn: { Task { await viewModel.signInClaude() } }
                 )
             }
@@ -57,6 +59,7 @@ private struct ServiceRow: View {
     let name: String
     let subtitle: String
     let isAuthenticated: Bool
+    let isRestoring: Bool
     let onSignIn: () -> Void
 
     var body: some View {
@@ -103,6 +106,7 @@ private struct ServiceRow: View {
                     .buttonStyle(.borderedProminent)
                     .tint(Color.brand)
                     .controlSize(.small)
+                    .disabled(isRestoring)
             }
         }
         .animation(.spring(response: 0.35, dampingFraction: 0.8), value: isAuthenticated)


### PR DESCRIPTION
## Summary
- Adds `isRestoring` prop to `ServiceRow` driven by `viewModel.isRestoringSession`
- Disables the Sign In button while auth coordinators are still probing for an existing session
- Prevents the `invalidTransition` error that fires when a user taps Sign In on a fresh install before bootstrap has finished

## Test plan
- [ ] Fresh install (AppZapper + archive): onboarding appears, Sign In buttons are briefly disabled, then become active once bootstrap completes
- [ ] Reset settings path: buttons are active immediately (bootstrap is already done by the time onboarding is triggered)
- [ ] Tapping Sign In after bootstrap completes opens the login window normally