### PR TITLE
feat: ask menu bar default in onboarding when both services connected

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,12 @@ on:
 
 jobs:
   claude-review:
-    if: github.actor != 'claude[bot]'
+    # Optional: Filter by PR author
+    # if: |
+    #   github.event.pull_request.user.login == 'external-contributor' ||
+    #   github.event.pull_request.user.login == 'new-developer' ||
+    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: github.actor != 'claude[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/AIQuota/Views/Onboarding/OnboardingView.swift
+++ b/AIQuota/Views/Onboarding/OnboardingView.swift
@@ -26,9 +26,16 @@ struct OnboardingView: View {
     @State private var step: OnboardingStep = .welcome
     @State private var direction: Int = 1   // +1 forward, -1 backward
 
-    // Fixed window size
-    static let width: CGFloat  = 520
-    static let height: CGFloat = 580
+    // Window size — expands when the menu bar picker is visible on the services step
+    static let width: CGFloat       = 520
+    static let height: CGFloat      = 580
+    static let heightWithPicker: CGFloat = 660
+
+    private var windowHeight: CGFloat {
+        step == .services && viewModel.isCodexAuthenticated && viewModel.isClaudeAuthenticated
+            ? Self.heightWithPicker
+            : Self.height
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -48,7 +55,8 @@ struct OnboardingView: View {
                 .frame(maxWidth: .infinity)
                 .background(.regularMaterial)
         }
-        .frame(width: Self.width, height: Self.height)
+        .frame(width: Self.width, height: windowHeight)
+        .animation(.spring(response: 0.35, dampingFraction: 0.85), value: windowHeight)
         .background(.regularMaterial)
         .onAppear {
             // Window is reused by SwiftUI — always restart from the beginning

--- a/AIQuota/Views/Onboarding/OnboardingView.swift
+++ b/AIQuota/Views/Onboarding/OnboardingView.swift
@@ -26,15 +26,13 @@ struct OnboardingView: View {
     @State private var step: OnboardingStep = .welcome
     @State private var direction: Int = 1   // +1 forward, -1 backward
 
-    // Window size — expands when the menu bar picker is visible on the services step
-    static let width: CGFloat       = 520
-    static let height: CGFloat      = 580
+    // Window size — services step is always taller to reserve space for the menu bar picker
+    static let width: CGFloat            = 520
+    static let height: CGFloat           = 580
     static let heightWithPicker: CGFloat = 660
 
     private var windowHeight: CGFloat {
-        step == .services && viewModel.isCodexAuthenticated && viewModel.isClaudeAuthenticated
-            ? Self.heightWithPicker
-            : Self.height
+        step == .services ? Self.heightWithPicker : Self.height
     }
 
     var body: some View {

--- a/AIQuota/Views/Onboarding/Steps/ServicesStepView.swift
+++ b/AIQuota/Views/Onboarding/Steps/ServicesStepView.swift
@@ -40,6 +40,17 @@ struct ServicesStepView: View {
             }
             .padding(.horizontal, 32)
 
+            if viewModel.isCodexAuthenticated && viewModel.isClaudeAuthenticated {
+                MenuBarDefaultPicker(
+                    selection: viewModel.settings.menuBarService,
+                    onSelect: { service in
+                        viewModel.settings.menuBarService = service
+                        viewModel.saveSettings()
+                    }
+                )
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+
             Spacer()
 
             Text("You can connect more services later in Settings.")
@@ -49,6 +60,8 @@ struct ServicesStepView: View {
                 .padding(.horizontal, 32)
                 .padding(.bottom, 12)
         }
+        .animation(.spring(response: 0.35, dampingFraction: 0.85),
+                   value: viewModel.isCodexAuthenticated && viewModel.isClaudeAuthenticated)
     }
 }
 
@@ -144,8 +157,8 @@ private struct MenuBarDefaultPicker: View {
                 .foregroundStyle(.secondary)
 
             HStack(spacing: 10) {
-                card(for: .codex,  logoName: "logo-openai", name: "Codex")
-                card(for: .claude, logoName: "logo-claude", name: "Claude Code")
+                card(for: .codex,  logoName: "logo-openai")
+                card(for: .claude, logoName: "logo-claude")
             }
         }
         .padding(.horizontal, 32)
@@ -153,7 +166,7 @@ private struct MenuBarDefaultPicker: View {
     }
 
     @ViewBuilder
-    private func card(for service: ServiceType, logoName: String, name: String) -> some View {
+    private func card(for service: ServiceType, logoName: String) -> some View {
         let isSelected = selection == service
         Button { onSelect(service) } label: {
             VStack(spacing: 10) {
@@ -176,7 +189,7 @@ private struct MenuBarDefaultPicker: View {
                             )
                     )
 
-                Text(name)
+                Text(service.displayName)
                     .font(.callout).fontWeight(.semibold)
 
                 Circle()

--- a/AIQuota/Views/Onboarding/Steps/ServicesStepView.swift
+++ b/AIQuota/Views/Onboarding/Steps/ServicesStepView.swift
@@ -150,7 +150,6 @@ private struct MenuBarDefaultPicker: View {
     var body: some View {
         VStack(spacing: 10) {
             Divider()
-                .padding(.horizontal, 32)
 
             Text("Which should show in your menu bar?")
                 .font(.footnote)

--- a/AIQuota/Views/Onboarding/Steps/ServicesStepView.swift
+++ b/AIQuota/Views/Onboarding/Steps/ServicesStepView.swift
@@ -127,3 +127,84 @@ private struct ServiceRow: View {
         )
     }
 }
+
+// MARK: - Menu Bar Default Picker
+
+private struct MenuBarDefaultPicker: View {
+    let selection: ServiceType
+    let onSelect: (ServiceType) -> Void
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Divider()
+                .padding(.horizontal, 32)
+
+            Text("Which should show in your menu bar?")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 10) {
+                card(for: .codex,  logoName: "logo-openai", name: "Codex")
+                card(for: .claude, logoName: "logo-claude", name: "Claude Code")
+            }
+        }
+        .padding(.horizontal, 32)
+        .padding(.top, 16)
+    }
+
+    @ViewBuilder
+    private func card(for service: ServiceType, logoName: String, name: String) -> some View {
+        let isSelected = selection == service
+        Button { onSelect(service) } label: {
+            VStack(spacing: 10) {
+                Image(logoName)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 36, height: 36)
+                    .padding(10)
+                    .background(
+                        Circle()
+                            .fill(isSelected
+                                  ? Color.brand.opacity(0.1)
+                                  : Color.secondary.opacity(0.08))
+                    )
+                    .overlay(
+                        Circle()
+                            .strokeBorder(
+                                isSelected ? Color.brand.opacity(0.3) : Color.clear,
+                                lineWidth: 1.5
+                            )
+                    )
+
+                Text(name)
+                    .font(.callout).fontWeight(.semibold)
+
+                Circle()
+                    .strokeBorder(isSelected ? Color.brand : Color.secondary.opacity(0.3),
+                                  lineWidth: 2)
+                    .frame(width: 16, height: 16)
+                    .overlay(
+                        Circle()
+                            .fill(Color.brand)
+                            .frame(width: 8, height: 8)
+                            .opacity(isSelected ? 1 : 0)
+                    )
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(.background)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .strokeBorder(
+                                isSelected ? Color.brand.opacity(0.35) : Color.secondary.opacity(0.12),
+                                lineWidth: 1
+                            )
+                    )
+            )
+            .animation(.spring(response: 0.3, dampingFraction: 0.75), value: isSelected)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/docs/superpowers/plans/2026-03-24-onboarding-menu-bar-default.md
+++ b/docs/superpowers/plans/2026-03-24-onboarding-menu-bar-default.md
@@ -1,0 +1,197 @@
+# Onboarding Menu Bar Default Picker — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When both Codex and Claude Code are connected during onboarding, show a pair of tap cards that let the user pick which service appears in the menu bar.
+
+**Architecture:** Add a private `MenuBarDefaultPicker` view to `ServicesStepView.swift`. Conditionally render it below the service rows when both services are authenticated, with a spring animation. Each card tap writes directly to `viewModel.settings.menuBarService` and calls `viewModel.saveSettings()` to persist.
+
+**Tech Stack:** SwiftUI, `@Observable` (macOS 14+), `AIQuotaKit.ServiceType`, `AIQuotaKit.AppSettings`
+
+---
+
+## File Map
+
+| Action | File |
+|--------|------|
+| Modify | `AIQuota/Views/Onboarding/Steps/ServicesStepView.swift` |
+
+No other files touched.
+
+---
+
+## Task 1: Add `MenuBarDefaultPicker` private view
+
+**Files:**
+- Modify: `AIQuota/Views/Onboarding/Steps/ServicesStepView.swift`
+
+This task adds the UI component only. No wiring yet — just the view rendering two cards correctly for a given `selection` binding and `onSelect` callback.
+
+- [ ] **Step 1: Add `MenuBarDefaultPicker` struct after the `ServiceRow` struct**
+
+Append this to the bottom of `ServicesStepView.swift` (after line 129, before the final blank line):
+
+```swift
+// MARK: - Menu Bar Default Picker
+
+private struct MenuBarDefaultPicker: View {
+    let selection: ServiceType
+    let onSelect: (ServiceType) -> Void
+
+    var body: some View {
+        VStack(spacing: 10) {
+            Divider()
+                .padding(.horizontal, 32)
+
+            Text("Which should show in your menu bar?")
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            HStack(spacing: 10) {
+                card(for: .codex,  logoName: "logo-openai", name: "Codex")
+                card(for: .claude, logoName: "logo-claude", name: "Claude Code")
+            }
+        }
+        .padding(.horizontal, 32)
+        .padding(.top, 16)
+    }
+
+    @ViewBuilder
+    private func card(for service: ServiceType, logoName: String, name: String) -> some View {
+        let isSelected = selection == service
+        Button { onSelect(service) } label: {
+            VStack(spacing: 10) {
+                Image(logoName)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 36, height: 36)
+                    .padding(10)
+                    .background(
+                        Circle()
+                            .fill(isSelected
+                                  ? Color.brand.opacity(0.1)
+                                  : Color.secondary.opacity(0.08))
+                    )
+                    .overlay(
+                        Circle()
+                            .strokeBorder(
+                                isSelected ? Color.brand.opacity(0.3) : Color.clear,
+                                lineWidth: 1.5
+                            )
+                    )
+
+                Text(name)
+                    .font(.callout).fontWeight(.semibold)
+
+                Circle()
+                    .strokeBorder(isSelected ? Color.brand : Color.secondary.opacity(0.3),
+                                  lineWidth: 2)
+                    .frame(width: 16, height: 16)
+                    .overlay(
+                        Circle()
+                            .fill(Color.brand)
+                            .frame(width: 8, height: 8)
+                            .opacity(isSelected ? 1 : 0)
+                    )
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(.background)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .strokeBorder(
+                                isSelected ? Color.brand.opacity(0.35) : Color.secondary.opacity(0.12),
+                                lineWidth: 1
+                            )
+                    )
+            )
+            .animation(.spring(response: 0.3, dampingFraction: 0.75), value: isSelected)
+        }
+        .buttonStyle(.plain)
+    }
+}
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+In Xcode: `Cmd+B` targeting **My Mac**.
+
+Expected: build succeeds. `MenuBarDefaultPicker` is defined but unused — that's fine for now.
+
+---
+
+## Task 2: Wire into `ServicesStepView`
+
+**Files:**
+- Modify: `AIQuota/Views/Onboarding/Steps/ServicesStepView.swift` (the `ServicesStepView.body`)
+
+- [ ] **Step 1: Replace the `Spacer()` in `ServicesStepView.body` with a conditional picker + spacer**
+
+Find this block in `ServicesStepView.body` (lines 43–50):
+
+```swift
+            Spacer()
+
+            Text("You can connect more services later in Settings.")
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+                .padding(.bottom, 12)
+```
+
+Replace with:
+
+```swift
+            if viewModel.isCodexAuthenticated && viewModel.isClaudeAuthenticated {
+                MenuBarDefaultPicker(
+                    selection: viewModel.settings.menuBarService,
+                    onSelect: { service in
+                        viewModel.settings.menuBarService = service
+                        viewModel.saveSettings()
+                    }
+                )
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+
+            Spacer()
+
+            Text("You can connect more services later in Settings.")
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+                .padding(.bottom, 12)
+```
+
+Then add an `.animation` modifier to the outer `VStack(spacing: 0)` in `ServicesStepView.body` so the transition fires when auth state changes. The `VStack` closes just before `body`'s closing brace. Add after it:
+
+```swift
+        .animation(.spring(response: 0.35, dampingFraction: 0.85),
+                   value: viewModel.isCodexAuthenticated && viewModel.isClaudeAuthenticated)
+```
+
+- [ ] **Step 2: Build to verify it compiles**
+
+`Cmd+B`. Expected: clean build.
+
+- [ ] **Step 3: Run the app and verify**
+
+Run the `AIQuota` scheme targeting **My Mac**.
+
+Reset onboarding so it shows on launch — in the app, go to **Settings → Reset Onboarding** (or run `viewModel.resetOnboardingForReplay()` in the debugger), then relaunch.
+
+Walk through to the **Services** step:
+1. Sign into only one service → picker should **not** appear.
+2. Sign into the second service → picker should **animate in** below the service rows.
+3. Tap each card → selection indicator moves correctly.
+4. Tap **Continue**, then quit and relaunch → open **Settings** and confirm the `menuBarService` matches what was selected.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add AIQuota/Views/Onboarding/Steps/ServicesStepView.swift
+git commit -m "feat: show menu bar default picker in onboarding when both services connected"
+```

--- a/docs/superpowers/specs/2026-03-24-onboarding-menu-bar-default-design.md
+++ b/docs/superpowers/specs/2026-03-24-onboarding-menu-bar-default-design.md
@@ -1,0 +1,74 @@
+# Onboarding: Menu Bar Default Picker
+
+**Date:** 2026-03-24
+**Status:** Approved
+
+---
+
+## Problem
+
+When a user connects both Codex and Claude Code during onboarding, they have no opportunity to choose which service appears in the menu bar. The setting exists in Settings, but first-run users will never see it. The app silently defaults to Codex.
+
+---
+
+## Solution
+
+Add an inline "Which should show in your menu bar?" choice to the existing **Services step** in onboarding. It appears only when both services are authenticated, and uses two large tap cards — a deliberate first-time-choice interaction rather than a settings-style widget.
+
+---
+
+## Design
+
+### Where
+
+`ServicesStepView.swift` only. No new step, no new model, no new files.
+
+### When it appears
+
+Conditionally rendered when `viewModel.isCodexAuthenticated && viewModel.isClaudeAuthenticated`. Animates in with a spring transition (`.opacity` + `.move(edge: .bottom)`) when that condition becomes true.
+
+### UI structure (within the services step, below service rows)
+
+```
+[ service row: Codex — Connected ]
+[ service row: Claude Code — Connected ]
+
+──── divider ────
+
+"Which should show in your menu bar?"   ← small secondary label
+
+[ card: Codex logo / name / radio ]  [ card: Claude Code logo / name / radio ]
+```
+
+### Tap cards
+
+- Two equal-width cards, side by side
+- Each shows: service logo, service name, radio indicator at bottom
+- Selected state: brand-purple border + tinted background + filled radio dot
+- Unselected state: subtle border + neutral background + empty radio circle
+- Tapping a card sets `viewModel.settings.menuBarService` and immediately calls `viewModel.saveSettings()` to persist the choice. (`SettingsView` auto-saves via `.onChange`, but `ServicesStepView` has no such modifier — `saveSettings()` must be called explicitly in the tap action.)
+- `saveSettings()` also calls `startAutoRefresh()` as a side effect; benign on repeated taps.
+- Default selection reflects the current value of `menuBarService` (`.codex` by default)
+
+### Layout
+
+The onboarding window is fixed at 520×580pt. The existing `Spacer()` between the service rows and footer hint will absorb the tap cards section (~130pt). No window size changes or scroll views needed.
+
+### Data binding
+
+`viewModel.settings.menuBarService` — type `ServiceType`, already persisted via `SharedDefaults`. No new state or model changes needed.
+
+### Existing behavior unchanged
+
+- `canAdvance` logic (require ≥1 service) — untouched
+- Progress dot count — untouched (no new step)
+- `resolvedMenuBarService` fallback in `AIQuotaApp` — untouched
+- Settings view picker — untouched (continues to work as before)
+
+---
+
+## Out of scope
+
+- Showing this UI when only one service is connected (not needed — only one option)
+- Changing the default value of `menuBarService` in `AppSettings`
+- Any changes outside `ServicesStepView.swift`


### PR DESCRIPTION
## Summary

- Adds `MenuBarDefaultPicker` to the Services onboarding step — appears with a spring animation when both Codex and Claude Code are connected
- Two tap cards (logo, label, radio indicator) let the user pick which service shows in the menu bar
- Selection writes to `settings.menuBarService` and persists immediately via `saveSettings()`

## Test Plan

- [x] Run onboarding via Settings → Guided Setup
- [x] Connect only one service → picker does not appear
- [x] Connect second service → picker animates in below service rows
- [x] Tap each card → selection indicator updates correctly
- [x] Complete onboarding → verify with `defaults read com.niederme.AIQuota menuBarService`