### PR TITLE
fix: skip claude-review when triggered by claude[bot]

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,7 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    if: github.actor != 'claude[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- Adds `if: github.actor != 'claude[bot]'` guard to the `claude-review` job
- Prevents the review workflow from triggering on bot-pushed commits, which caused it to fail with a "non-human actor" error from `claude-code-action`

## Test Plan

- [ ] Merge this PR to main
- [ ] Verify subsequent bot commits on PRs no longer trigger a failing `claude-review` run