### PR TITLE
fix: onboarding window vibrancy, fixed height, and hidden title bar

### DIFF
--- a/AIQuota/AIQuotaApp.swift
+++ b/AIQuota/AIQuotaApp.swift
@@ -51,6 +51,7 @@ struct AIQuotaApp: App {
                 .environment(viewModel)
                 .background(WindowVibrancyInstaller())
         }
+        .windowStyle(.hiddenTitleBar)
         .windowResizability(.contentSize)
         .defaultPosition(.center)
 
@@ -142,21 +143,16 @@ private extension View {
 /// Zero-size view that reaches up to the hosting NSWindow and enables
 /// vibrancy + transparency so SwiftUI's .thinMaterial fills the whole window.
 private struct WindowVibrancyInstaller: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        // Defer so the window is attached by the time we walk the hierarchy
+    func makeNSView(context: Context) -> NSView { NSView() }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        // Defer past SwiftUI's own window-configuration pass so our overrides win
         DispatchQueue.main.async {
-            guard let window = view.window else { return }
+            guard let window = nsView.window else { return }
             window.isOpaque = false
             window.backgroundColor = .clear
-            // Extend content view under the title bar so the material shows through
-            window.titlebarAppearsTransparent = true
-            window.titleVisibility = .hidden
-            window.styleMask.insert(.fullSizeContentView)
             // Float above other apps so it's never lost behind them
             window.level = .floating
         }
-        return view
     }
-    func updateNSView(_ nsView: NSView, context: Context) {}
 }

--- a/AIQuota/AIQuotaApp.swift
+++ b/AIQuota/AIQuotaApp.swift
@@ -140,7 +140,7 @@ private extension View {
 // MARK: - Window vibrancy installer
 
 /// Zero-size view that reaches up to the hosting NSWindow and enables
-/// vibrancy + transparency so SwiftUI's .ultraThinMaterial fills the whole window.
+/// vibrancy + transparency so SwiftUI's .thinMaterial fills the whole window.
 private struct WindowVibrancyInstaller: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView()

--- a/AIQuota/Views/Onboarding/OnboardingView.swift
+++ b/AIQuota/Views/Onboarding/OnboardingView.swift
@@ -46,10 +46,10 @@ struct OnboardingView: View {
                 .padding(.horizontal, 28)
                 .padding(.vertical, 16)
                 .frame(maxWidth: .infinity)
-                .background(.regularMaterial)
+                .background(.thinMaterial)
         }
         .frame(width: Self.width, height: Self.height)
-        .background(.regularMaterial)
+        .background(.thinMaterial)
         .onAppear {
             // Window is reused by SwiftUI — always restart from the beginning
             step = .welcome

--- a/AIQuota/Views/Onboarding/OnboardingView.swift
+++ b/AIQuota/Views/Onboarding/OnboardingView.swift
@@ -26,14 +26,9 @@ struct OnboardingView: View {
     @State private var step: OnboardingStep = .welcome
     @State private var direction: Int = 1   // +1 forward, -1 backward
 
-    // Window size — services step is always taller to reserve space for the menu bar picker
-    static let width: CGFloat            = 520
-    static let height: CGFloat           = 580
-    static let heightWithPicker: CGFloat = 660
-
-    private var windowHeight: CGFloat {
-        step == .services ? Self.heightWithPicker : Self.height
-    }
+    // Fixed window size — tall enough for the services step with the menu bar picker
+    static let width:  CGFloat = 520
+    static let height: CGFloat = 660
 
     var body: some View {
         VStack(spacing: 0) {
@@ -46,16 +41,15 @@ struct OnboardingView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .animation(.spring(response: 0.35, dampingFraction: 0.85), value: step)
 
-            // Navigation bar — material surface separates it from content naturally
+            // Navigation bar
             navigationBar
                 .padding(.horizontal, 28)
                 .padding(.vertical, 16)
                 .frame(maxWidth: .infinity)
-                .background(.thinMaterial)
         }
-        .frame(width: Self.width, height: windowHeight)
-        .animation(.spring(response: 0.35, dampingFraction: 0.85), value: windowHeight)
-        .background(.thinMaterial)
+        .frame(width: Self.width, height: Self.height)
+        .ignoresSafeArea()
+        .background(.regularMaterial)
         .onAppear {
             // Window is reused by SwiftUI — always restart from the beginning
             step = .welcome


### PR DESCRIPTION
## Summary

- Switches to `.windowStyle(.hiddenTitleBar)` to eliminate the dark titlebar shade over the onboarding window
- Moves window vibrancy config (`isOpaque`, `backgroundColor`, `level`) to `updateNSView` with `DispatchQueue.main.async` so our overrides run after SwiftUI's own window setup pass
- Changes onboarding background from `.thinMaterial` to `.regularMaterial` for a more substantial frosted glass look
- Fixes window height to 660pt for all steps — no more resize animation between slides
- Removes duplicate `.thinMaterial` on the bottom nav bar; adds `.ignoresSafeArea()` to fill the full window

## Test plan

- [x] Launch onboarding from Settings → reset onboarding → relaunch
- [x] Verify no dark titlebar shade; traffic lights float over content
- [x] Step through all 5 onboarding slides — window height stays fixed
- [x] Confirm regularMaterial frosted glass shows correctly over varied backgrounds