### PR TITLE
fix: add 3s timeout to syncCookies() to prevent hang after settings reset

### DIFF
--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeAuthManager.swift
@@ -93,8 +93,27 @@ public final class ClaudeAuthManager: NSObject, ObservableObject {
     // MARK: - Cookie Sync
 
     public func syncCookies() async {
+        // Use a simple reference-type gate so the continuation is resumed exactly
+        // once — by whichever fires first: getAllCookies or the 3-second timeout.
+        // Both closures run on the main thread (syncCookies is @MainActor and
+        // getAllCookies delivers on the main thread), so no locking is needed.
+        final class Once: @unchecked Sendable { var fired = false }
+        let gate = Once()
+
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            // Safety valve: if the WKWebsiteDataStore callback stalls (can happen
+            // when WebKit's process restarts after a data-store reset or sign-out),
+            // unblock after 3 s so fetchUsage() can proceed and fail fast with a
+            // missing-cookie error rather than hanging with isClaudeLoading = true.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+                guard !gate.fired else { return }
+                gate.fired = true
+                continuation.resume()
+            }
+
             WKWebsiteDataStore.default().httpCookieStore.getAllCookies { cookies in
+                guard !gate.fired else { return }
+                gate.fired = true
                 for cookie in cookies where cookie.domain.contains("claude.ai") {
                     HTTPCookieStorage.shared.setCookie(cookie)
                 }


### PR DESCRIPTION
## Summary

- `syncCookies()` had no timeout on its `WKWebsiteDataStore.getAllCookies` call
- When WebKit's process restarts (e.g. after sign-out or settings reset), the callback can silently never fire
- This left `isClaudeLoading = true` forever, blocking all subsequent `refreshClaude()` calls
- Fix: race the callback against a 3-second `DispatchQueue.main.asyncAfter` — whichever fires first wins, preventing the indefinite hang

## Test plan

- [ ] Sign out of Claude Code, then sign back in — usage should load without hanging
- [ ] Reset app settings and re-authenticate — spinners should resolve within 3 seconds at most

🤖 Generated with [Claude Code](https://claude.com/claude-code)