### PR TITLE
Settings structural pass — wider window, section reorder, consolidated notification toggles

### DIFF
--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -163,6 +163,13 @@ final class QuotaViewModel {
         codexUsage  = SharedDefaults.loadCachedUsage()
         claudeUsage = SharedDefaults.loadCachedClaudeUsage()
 
+        // Normalise any mixed per-threshold notification state from pre-consolidation builds.
+        // OR-resolves each group (any=true → all-true) so aggregate toggles always see
+        // a clean on/off state from the first render.
+        let preNorm = settings
+        settings.notifications.normalizeThresholds()
+        if settings != preNorm { SharedDefaults.saveSettings(settings) }
+
         // Observe coordinator state streams and drive UI state + auto-refresh.
         Task { [weak self] in
             guard let self else { return }

--- a/AIQuota/Views/Onboarding/Steps/NotificationsStepView.swift
+++ b/AIQuota/Views/Onboarding/Steps/NotificationsStepView.swift
@@ -48,22 +48,18 @@ struct NotificationsStepView: View {
 
                 // ── Codex ──────────────────────────────────────────────
                 if viewModel.isCodexEnrolled {
-                    Section {
-                        serviceRow(logo: "logo-openai", name: "Codex",
+                    Section("Codex") {
+                        serviceRow(logo: "logo-openai",
                                    isOn: sectionsEnabled ? $vm.settings.notifications.codexEnabled : .constant(false))
 
                         if sectionsEnabled && vm.settings.notifications.codexEnabled {
                             subHeader("5-hour window")
-                            Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.codex5hAt15)
-                            Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.codex5hAt5)
-                            Toggle("Limit reached",           isOn: $vm.settings.notifications.codex5hLimitReached)
-                            Toggle("Window reset",            isOn: $vm.settings.notifications.codex5hReset)
+                            Toggle("Threshold alerts", isOn: $vm.settings.notifications.codex5hThresholdAlerts)
+                            Toggle("Window reset",     isOn: $vm.settings.notifications.codex5hReset)
 
                             subHeader("Weekly usage")
-                            Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.codexAt15)
-                            Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.codexAt5)
-                            Toggle("Limit reached",           isOn: $vm.settings.notifications.codexLimitReached)
-                            Toggle("Weekly reset",            isOn: $vm.settings.notifications.codexReset)
+                            Toggle("Threshold alerts", isOn: $vm.settings.notifications.codexWeeklyThresholdAlerts)
+                            Toggle("Weekly reset",     isOn: $vm.settings.notifications.codexReset)
                         }
                     }
                     .disabled(!sectionsEnabled)
@@ -72,22 +68,18 @@ struct NotificationsStepView: View {
 
                 // ── Claude Code ────────────────────────────────────────
                 if viewModel.isClaudeEnrolled {
-                    Section {
-                        serviceRow(logo: "logo-claude", name: "Claude Code",
+                    Section("Claude Code") {
+                        serviceRow(logo: "logo-claude",
                                    isOn: sectionsEnabled ? $vm.settings.notifications.claudeEnabled : .constant(false))
 
                         if sectionsEnabled && vm.settings.notifications.claudeEnabled {
                             subHeader("5-hour window")
-                            Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.claude5hAt15)
-                            Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.claude5hAt5)
-                            Toggle("Limit reached",           isOn: $vm.settings.notifications.claude5hLimitReached)
-                            Toggle("Window reset",            isOn: $vm.settings.notifications.claude5hReset)
+                            Toggle("Threshold alerts", isOn: $vm.settings.notifications.claude5hThresholdAlerts)
+                            Toggle("Window reset",     isOn: $vm.settings.notifications.claude5hReset)
 
                             subHeader("7-day window")
-                            Toggle("80% used (high)",         isOn: $vm.settings.notifications.claude7dAt80)
-                            Toggle("95% used (critical)",     isOn: $vm.settings.notifications.claude7dAt95)
-                            Toggle("Limit reached",           isOn: $vm.settings.notifications.claude7dLimitReached)
-                            Toggle("Period reset",            isOn: $vm.settings.notifications.claude7dReset)
+                            Toggle("Threshold alerts", isOn: $vm.settings.notifications.claude7dThresholdAlerts)
+                            Toggle("Period reset",     isOn: $vm.settings.notifications.claude7dReset)
                         }
                     }
                     .disabled(!sectionsEnabled)
@@ -103,8 +95,6 @@ struct NotificationsStepView: View {
             }
             .formStyle(.grouped)
             .animation(.spring(response: 0.4, dampingFraction: 0.85), value: sectionsEnabled)
-            .animation(.spring(response: 0.3, dampingFraction: 0.85), value: viewModel.settings.notifications.codexEnabled)
-            .animation(.spring(response: 0.3, dampingFraction: 0.85), value: viewModel.settings.notifications.claudeEnabled)
         }
         .task { await checkPermission() }
         .onChange(of: viewModel.settings) { viewModel.saveSettings() }
@@ -114,15 +104,12 @@ struct NotificationsStepView: View {
 
     /// Bold service row: logo + name on the left, switch on the right.
     @ViewBuilder
-    private func serviceRow(logo: String, name: String, isOn: Binding<Bool>) -> some View {
+    private func serviceRow(logo: String, isOn: Binding<Bool>) -> some View {
         HStack(spacing: 10) {
             Image(logo)
                 .resizable()
                 .scaledToFit()
                 .frame(width: 18, height: 18)
-            Text(name)
-                .fontWeight(.semibold)
-            Spacer()
             Toggle("", isOn: isOn)
                 .toggleStyle(.switch)
                 .labelsHidden()

--- a/AIQuota/Views/Onboarding/Steps/NotificationsStepView.swift
+++ b/AIQuota/Views/Onboarding/Steps/NotificationsStepView.swift
@@ -102,7 +102,8 @@ struct NotificationsStepView: View {
 
     // MARK: - Helpers
 
-    /// Bold service row: logo + name on the left, switch on the right.
+    /// Service row: logo on the left, enable/disable switch on the right.
+    /// The service name is provided by the enclosing Section title.
     @ViewBuilder
     private func serviceRow(logo: String, isOn: Binding<Bool>) -> some View {
         HStack(spacing: 10) {

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -81,7 +81,7 @@ struct SettingsView: View {
             // MARK: Notifications — Codex
             if viewModel.isCodexEnrolled {
                 Section("Codex") {
-                    notifServiceRow(logo: "logo-openai", name: "Codex",
+                    notifServiceRow(logo: "logo-openai",
                                     isOn: notifSectionsEnabled ? $vm.settings.notifications.codexEnabled : .constant(false))
                     if notifSectionsEnabled && vm.settings.notifications.codexEnabled {
                         notifSubHeader("5-hour window")
@@ -100,7 +100,7 @@ struct SettingsView: View {
             // MARK: Notifications — Claude Code
             if viewModel.isClaudeEnrolled {
                 Section("Claude Code") {
-                    notifServiceRow(logo: "logo-claude", name: "Claude Code",
+                    notifServiceRow(logo: "logo-claude",
                                     isOn: notifSectionsEnabled ? $vm.settings.notifications.claudeEnabled : .constant(false))
                     if notifSectionsEnabled && vm.settings.notifications.claudeEnabled {
                         notifSubHeader("5-hour window")
@@ -206,15 +206,12 @@ struct SettingsView: View {
     // MARK: - Notification helpers
 
     @ViewBuilder
-    private func notifServiceRow(logo: String, name: String, isOn: Binding<Bool>) -> some View {
+    private func notifServiceRow(logo: String, isOn: Binding<Bool>) -> some View {
         HStack(spacing: 10) {
             Image(logo)
                 .resizable()
                 .scaledToFit()
                 .frame(width: 18, height: 18)
-            Text(name)
-                .fontWeight(.semibold)
-            Spacer()
             Toggle("", isOn: isOn)
                 .toggleStyle(.switch)
                 .labelsHidden()

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -205,6 +205,8 @@ struct SettingsView: View {
 
     // MARK: - Notification helpers
 
+    /// Service row: logo on the left, enable/disable switch on the right.
+    /// The service name is provided by the enclosing Section title.
     @ViewBuilder
     private func notifServiceRow(logo: String, isOn: Binding<Bool>) -> some View {
         HStack(spacing: 10) {

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -40,6 +40,24 @@ struct SettingsView: View {
                 LaunchAtLoginToggle()
             }
 
+            // MARK: Accounts
+            Section("Accounts") {
+                LabeledContent("Codex") {
+                    if viewModel.isCodexAuthenticated {
+                        Button("Sign Out", role: .destructive) { viewModel.signOut() }
+                    } else {
+                        Button("Sign In") { Task { await viewModel.signIn() } }
+                    }
+                }
+                LabeledContent("Claude Code") {
+                    if viewModel.isClaudeAuthenticated {
+                        Button("Sign Out", role: .destructive) { viewModel.signOutClaude() }
+                    } else {
+                        Button("Sign In") { Task { await viewModel.signInClaude() } }
+                    }
+                }
+            }
+
             // MARK: Notifications — master toggle
             Section("Notifications") {
                 Toggle("Enable notifications", isOn: $vm.settings.notifications.enabled)
@@ -62,21 +80,17 @@ struct SettingsView: View {
 
             // MARK: Notifications — Codex
             if viewModel.isCodexEnrolled {
-                Section {
+                Section("Codex") {
                     notifServiceRow(logo: "logo-openai", name: "Codex",
                                     isOn: notifSectionsEnabled ? $vm.settings.notifications.codexEnabled : .constant(false))
                     if notifSectionsEnabled && vm.settings.notifications.codexEnabled {
                         notifSubHeader("5-hour window")
-                        Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.codex5hAt15)
-                        Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.codex5hAt5)
-                        Toggle("Limit reached",           isOn: $vm.settings.notifications.codex5hLimitReached)
-                        Toggle("Window reset",            isOn: $vm.settings.notifications.codex5hReset)
+                        Toggle("Threshold alerts", isOn: $vm.settings.notifications.codex5hThresholdAlerts)
+                        Toggle("Window reset",     isOn: $vm.settings.notifications.codex5hReset)
 
                         notifSubHeader("Weekly usage")
-                        Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.codexAt15)
-                        Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.codexAt5)
-                        Toggle("Limit reached",           isOn: $vm.settings.notifications.codexLimitReached)
-                        Toggle("Weekly reset",            isOn: $vm.settings.notifications.codexReset)
+                        Toggle("Threshold alerts", isOn: $vm.settings.notifications.codexWeeklyThresholdAlerts)
+                        Toggle("Weekly reset",     isOn: $vm.settings.notifications.codexReset)
                     }
                 }
                 .disabled(!notifSectionsEnabled)
@@ -85,21 +99,17 @@ struct SettingsView: View {
 
             // MARK: Notifications — Claude Code
             if viewModel.isClaudeEnrolled {
-                Section {
+                Section("Claude Code") {
                     notifServiceRow(logo: "logo-claude", name: "Claude Code",
                                     isOn: notifSectionsEnabled ? $vm.settings.notifications.claudeEnabled : .constant(false))
                     if notifSectionsEnabled && vm.settings.notifications.claudeEnabled {
                         notifSubHeader("5-hour window")
-                        Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.claude5hAt15)
-                        Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.claude5hAt5)
-                        Toggle("Limit reached",           isOn: $vm.settings.notifications.claude5hLimitReached)
-                        Toggle("Window reset",            isOn: $vm.settings.notifications.claude5hReset)
+                        Toggle("Threshold alerts", isOn: $vm.settings.notifications.claude5hThresholdAlerts)
+                        Toggle("Window reset",     isOn: $vm.settings.notifications.claude5hReset)
 
                         notifSubHeader("7-day window")
-                        Toggle("80% used (high)",         isOn: $vm.settings.notifications.claude7dAt80)
-                        Toggle("95% used (critical)",     isOn: $vm.settings.notifications.claude7dAt95)
-                        Toggle("Limit reached",           isOn: $vm.settings.notifications.claude7dLimitReached)
-                        Toggle("Period reset",            isOn: $vm.settings.notifications.claude7dReset)
+                        Toggle("Threshold alerts", isOn: $vm.settings.notifications.claude7dThresholdAlerts)
+                        Toggle("Period reset",     isOn: $vm.settings.notifications.claude7dReset)
                     }
                 }
                 .disabled(!notifSectionsEnabled)
@@ -118,24 +128,6 @@ struct SettingsView: View {
                 Toggle("Check for updates automatically", isOn: $u.automaticallyChecksForUpdates)
                 Button("Check Now") { updater.checkForUpdates() }
                     .disabled(!updater.canCheckForUpdates)
-            }
-
-            // MARK: Accounts
-            Section("Accounts") {
-                LabeledContent("Codex") {
-                    if viewModel.isCodexAuthenticated {
-                        Button("Sign Out", role: .destructive) { viewModel.signOut() }
-                    } else {
-                        Button("Sign In") { Task { await viewModel.signIn() } }
-                    }
-                }
-                LabeledContent("Claude Code") {
-                    if viewModel.isClaudeAuthenticated {
-                        Button("Sign Out", role: .destructive) { viewModel.signOutClaude() }
-                    } else {
-                        Button("Sign In") { Task { await viewModel.signInClaude() } }
-                    }
-                }
             }
 
             // MARK: Onboarding
@@ -181,7 +173,7 @@ struct SettingsView: View {
         }
         .id(formID)
         .formStyle(.grouped)
-        .frame(width: 400)
+        .frame(width: 500)
         .navigationTitle("Settings")
         .task { await checkNotifPermission() }
         // macOS keeps the Settings window alive between opens (just hides it),
@@ -191,8 +183,6 @@ struct SettingsView: View {
             formID = UUID()
         }
         .animation(.spring(response: 0.4, dampingFraction: 0.85), value: notifSectionsEnabled)
-        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: viewModel.settings.notifications.codexEnabled)
-        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: viewModel.settings.notifications.claudeEnabled)
         .onChange(of: viewModel.settings) { viewModel.saveSettings() }
         .background(FloatingWindowElevator())
         .confirmationDialog(

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift
@@ -58,6 +58,49 @@ public struct NotificationPreferences: Codable, Sendable, Equatable {
 
     public init() {}
 
+    // MARK: - Aggregate computed properties (UI consolidation)
+    // Each property covers one window type's threshold alerts (at-%, limit reached).
+    // Reads true if any underlying field is on; writes all three simultaneously.
+
+    public var codex5hThresholdAlerts: Bool {
+        get { codex5hAt15 || codex5hAt5 || codex5hLimitReached }
+        set { codex5hAt15 = newValue; codex5hAt5 = newValue; codex5hLimitReached = newValue }
+    }
+
+    public var codexWeeklyThresholdAlerts: Bool {
+        get { codexAt15 || codexAt5 || codexLimitReached }
+        set { codexAt15 = newValue; codexAt5 = newValue; codexLimitReached = newValue }
+    }
+
+    public var claude5hThresholdAlerts: Bool {
+        get { claude5hAt15 || claude5hAt5 || claude5hLimitReached }
+        set { claude5hAt15 = newValue; claude5hAt5 = newValue; claude5hLimitReached = newValue }
+    }
+
+    public var claude7dThresholdAlerts: Bool {
+        get { claude7dAt80 || claude7dAt95 || claude7dLimitReached }
+        set { claude7dAt80 = newValue; claude7dAt95 = newValue; claude7dLimitReached = newValue }
+    }
+
+    // MARK: - Migration
+
+    /// Normalises any threshold group where the three underlying booleans are not all
+    /// the same value. Mixed groups are resolved to their OR result (any=true → all-true).
+    /// Call once on app launch before UI renders; subsequent interactions use the
+    /// aggregate computed properties above which always write all three uniformly.
+    public mutating func normalizeThresholds() {
+        func normalize(_ a: inout Bool, _ b: inout Bool, _ c: inout Bool) {
+            let resolved = a || b || c
+            if a != resolved || b != resolved || c != resolved {
+                a = resolved; b = resolved; c = resolved
+            }
+        }
+        normalize(&codex5hAt15,  &codex5hAt5,  &codex5hLimitReached)
+        normalize(&codexAt15,    &codexAt5,    &codexLimitReached)
+        normalize(&claude5hAt15, &claude5hAt5, &claude5hLimitReached)
+        normalize(&claude7dAt80, &claude7dAt95, &claude7dLimitReached)
+    }
+
     /// Migration-safe decoder: missing keys fall back to defaults rather than throwing.
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift
@@ -58,6 +58,30 @@ public struct NotificationPreferences: Codable, Sendable, Equatable {
 
     public init() {}
 
+    /// Migration-safe decoder: missing keys fall back to defaults rather than throwing.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        enabled              = try c.decodeIfPresent(Bool.self, forKey: .enabled)              ?? true
+        codexEnabled         = try c.decodeIfPresent(Bool.self, forKey: .codexEnabled)         ?? true
+        claudeEnabled        = try c.decodeIfPresent(Bool.self, forKey: .claudeEnabled)        ?? true
+        codex5hAt15          = try c.decodeIfPresent(Bool.self, forKey: .codex5hAt15)          ?? true
+        codex5hAt5           = try c.decodeIfPresent(Bool.self, forKey: .codex5hAt5)           ?? true
+        codex5hLimitReached  = try c.decodeIfPresent(Bool.self, forKey: .codex5hLimitReached)  ?? true
+        codex5hReset         = try c.decodeIfPresent(Bool.self, forKey: .codex5hReset)         ?? true
+        codexAt15            = try c.decodeIfPresent(Bool.self, forKey: .codexAt15)            ?? true
+        codexAt5             = try c.decodeIfPresent(Bool.self, forKey: .codexAt5)             ?? true
+        codexLimitReached    = try c.decodeIfPresent(Bool.self, forKey: .codexLimitReached)    ?? true
+        codexReset           = try c.decodeIfPresent(Bool.self, forKey: .codexReset)           ?? true
+        claude5hAt15         = try c.decodeIfPresent(Bool.self, forKey: .claude5hAt15)         ?? true
+        claude5hAt5          = try c.decodeIfPresent(Bool.self, forKey: .claude5hAt5)          ?? true
+        claude5hLimitReached = try c.decodeIfPresent(Bool.self, forKey: .claude5hLimitReached) ?? true
+        claude5hReset        = try c.decodeIfPresent(Bool.self, forKey: .claude5hReset)        ?? true
+        claude7dAt80         = try c.decodeIfPresent(Bool.self, forKey: .claude7dAt80)         ?? true
+        claude7dAt95         = try c.decodeIfPresent(Bool.self, forKey: .claude7dAt95)         ?? true
+        claude7dLimitReached = try c.decodeIfPresent(Bool.self, forKey: .claude7dLimitReached) ?? true
+        claude7dReset        = try c.decodeIfPresent(Bool.self, forKey: .claude7dReset)        ?? true
+    }
+
     // MARK: - Aggregate computed properties (UI consolidation)
     // Each property covers one window type's threshold alerts (at-%, limit reached).
     // Reads true if any underlying field is on; writes all three simultaneously.
@@ -99,30 +123,6 @@ public struct NotificationPreferences: Codable, Sendable, Equatable {
         normalize(&codexAt15,    &codexAt5,    &codexLimitReached)
         normalize(&claude5hAt15, &claude5hAt5, &claude5hLimitReached)
         normalize(&claude7dAt80, &claude7dAt95, &claude7dLimitReached)
-    }
-
-    /// Migration-safe decoder: missing keys fall back to defaults rather than throwing.
-    public init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        enabled              = try c.decodeIfPresent(Bool.self, forKey: .enabled)              ?? true
-        codexEnabled         = try c.decodeIfPresent(Bool.self, forKey: .codexEnabled)         ?? true
-        claudeEnabled        = try c.decodeIfPresent(Bool.self, forKey: .claudeEnabled)        ?? true
-        codex5hAt15          = try c.decodeIfPresent(Bool.self, forKey: .codex5hAt15)          ?? true
-        codex5hAt5           = try c.decodeIfPresent(Bool.self, forKey: .codex5hAt5)           ?? true
-        codex5hLimitReached  = try c.decodeIfPresent(Bool.self, forKey: .codex5hLimitReached)  ?? true
-        codex5hReset         = try c.decodeIfPresent(Bool.self, forKey: .codex5hReset)         ?? true
-        codexAt15            = try c.decodeIfPresent(Bool.self, forKey: .codexAt15)            ?? true
-        codexAt5             = try c.decodeIfPresent(Bool.self, forKey: .codexAt5)             ?? true
-        codexLimitReached    = try c.decodeIfPresent(Bool.self, forKey: .codexLimitReached)    ?? true
-        codexReset           = try c.decodeIfPresent(Bool.self, forKey: .codexReset)           ?? true
-        claude5hAt15         = try c.decodeIfPresent(Bool.self, forKey: .claude5hAt15)         ?? true
-        claude5hAt5          = try c.decodeIfPresent(Bool.self, forKey: .claude5hAt5)          ?? true
-        claude5hLimitReached = try c.decodeIfPresent(Bool.self, forKey: .claude5hLimitReached) ?? true
-        claude5hReset        = try c.decodeIfPresent(Bool.self, forKey: .claude5hReset)        ?? true
-        claude7dAt80         = try c.decodeIfPresent(Bool.self, forKey: .claude7dAt80)         ?? true
-        claude7dAt95         = try c.decodeIfPresent(Bool.self, forKey: .claude7dAt95)         ?? true
-        claude7dLimitReached = try c.decodeIfPresent(Bool.self, forKey: .claude7dLimitReached) ?? true
-        claude7dReset        = try c.decodeIfPresent(Bool.self, forKey: .claude7dReset)        ?? true
     }
 }
 

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/NotificationPreferencesNormalizationTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/NotificationPreferencesNormalizationTests.swift
@@ -26,6 +26,8 @@ struct NotificationPreferencesNormalizationTests {
         prefs.claude7dAt80 = false; prefs.claude7dAt95 = false; prefs.claude7dLimitReached = false
         prefs.normalizeThresholds()
         #expect(!prefs.codex5hAt15 && !prefs.codex5hAt5 && !prefs.codex5hLimitReached)
+        #expect(!prefs.codexAt15 && !prefs.codexAt5 && !prefs.codexLimitReached)
+        #expect(!prefs.claude5hAt15 && !prefs.claude5hAt5 && !prefs.claude5hLimitReached)
         #expect(!prefs.claude7dAt80 && !prefs.claude7dAt95 && !prefs.claude7dLimitReached)
     }
 
@@ -82,5 +84,31 @@ struct NotificationPreferencesNormalizationTests {
         prefs.codex5hAt15 = false; prefs.codex5hAt5 = false; prefs.codex5hLimitReached = false
         prefs.codex5hThresholdAlerts = true
         #expect(prefs.codex5hAt15 && prefs.codex5hAt5 && prefs.codex5hLimitReached)
+    }
+
+    @Test("codexWeeklyThresholdAlerts is true when all three are true")
+    func codexWeeklyAggregateAllOnIsTrue() {
+        let prefs = NotificationPreferences()
+        #expect(prefs.codexWeeklyThresholdAlerts == true)
+    }
+
+    @Test("claude5hThresholdAlerts is true when all three are true")
+    func claude5hAggregateAllOnIsTrue() {
+        let prefs = NotificationPreferences()
+        #expect(prefs.claude5hThresholdAlerts == true)
+    }
+
+    @Test("claude7dThresholdAlerts is false when all three are false")
+    func claude7dAggregateAllOffIsFalse() {
+        var prefs = NotificationPreferences()
+        prefs.claude7dAt80 = false; prefs.claude7dAt95 = false; prefs.claude7dLimitReached = false
+        #expect(prefs.claude7dThresholdAlerts == false)
+    }
+
+    @Test("setting claude7dThresholdAlerts=false clears all three fields")
+    func claude7dAggregateSetFalseClearsAll() {
+        var prefs = NotificationPreferences()
+        prefs.claude7dThresholdAlerts = false
+        #expect(!prefs.claude7dAt80 && !prefs.claude7dAt95 && !prefs.claude7dLimitReached)
     }
 }

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/NotificationPreferencesNormalizationTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/NotificationPreferencesNormalizationTests.swift
@@ -1,0 +1,86 @@
+import Testing
+@testable import AIQuotaKit
+
+@Suite("NotificationPreferences normalization")
+struct NotificationPreferencesNormalizationTests {
+
+    // MARK: - normalizeThresholds()
+
+    @Test("all-on groups stay all-on")
+    func allOnUnchanged() {
+        var prefs = NotificationPreferences()
+        // defaults are all true — should be a no-op
+        prefs.normalizeThresholds()
+        #expect(prefs.codex5hAt15 && prefs.codex5hAt5 && prefs.codex5hLimitReached)
+        #expect(prefs.codexAt15 && prefs.codexAt5 && prefs.codexLimitReached)
+        #expect(prefs.claude5hAt15 && prefs.claude5hAt5 && prefs.claude5hLimitReached)
+        #expect(prefs.claude7dAt80 && prefs.claude7dAt95 && prefs.claude7dLimitReached)
+    }
+
+    @Test("all-off groups stay all-off")
+    func allOffUnchanged() {
+        var prefs = NotificationPreferences()
+        prefs.codex5hAt15 = false; prefs.codex5hAt5 = false; prefs.codex5hLimitReached = false
+        prefs.codexAt15 = false; prefs.codexAt5 = false; prefs.codexLimitReached = false
+        prefs.claude5hAt15 = false; prefs.claude5hAt5 = false; prefs.claude5hLimitReached = false
+        prefs.claude7dAt80 = false; prefs.claude7dAt95 = false; prefs.claude7dLimitReached = false
+        prefs.normalizeThresholds()
+        #expect(!prefs.codex5hAt15 && !prefs.codex5hAt5 && !prefs.codex5hLimitReached)
+        #expect(!prefs.claude7dAt80 && !prefs.claude7dAt95 && !prefs.claude7dLimitReached)
+    }
+
+    @Test("mixed group where any=true normalises to all-true")
+    func mixedPartialOnBecomesAllOn() {
+        var prefs = NotificationPreferences()
+        // Only one of three is on in the Codex 5h group
+        prefs.codex5hAt15 = false
+        prefs.codex5hAt5 = false
+        prefs.codex5hLimitReached = true   // one left on
+        prefs.normalizeThresholds()
+        #expect(prefs.codex5hAt15)
+        #expect(prefs.codex5hAt5)
+        #expect(prefs.codex5hLimitReached)
+    }
+
+    @Test("mixed group where any=true normalises independently per group")
+    func eachGroupNormalisedIndependently() {
+        var prefs = NotificationPreferences()
+        // Codex weekly: only limit reached is on — should become all-on
+        prefs.codexAt15 = false; prefs.codexAt5 = false; prefs.codexLimitReached = true
+        // Claude 7d: all off — should stay all-off
+        prefs.claude7dAt80 = false; prefs.claude7dAt95 = false; prefs.claude7dLimitReached = false
+        prefs.normalizeThresholds()
+        #expect(prefs.codexAt15 && prefs.codexAt5 && prefs.codexLimitReached)
+        #expect(!prefs.claude7dAt80 && !prefs.claude7dAt95 && !prefs.claude7dLimitReached)
+    }
+
+    // MARK: - Aggregate computed properties
+
+    @Test("codex5hThresholdAlerts is true when all three are true")
+    func aggregateAllOnIsTrue() {
+        let prefs = NotificationPreferences()
+        #expect(prefs.codex5hThresholdAlerts == true)
+    }
+
+    @Test("codex5hThresholdAlerts is false when all three are false")
+    func aggregateAllOffIsFalse() {
+        var prefs = NotificationPreferences()
+        prefs.codex5hAt15 = false; prefs.codex5hAt5 = false; prefs.codex5hLimitReached = false
+        #expect(prefs.codex5hThresholdAlerts == false)
+    }
+
+    @Test("setting codex5hThresholdAlerts=false clears all three fields")
+    func aggregateSetFalseClearsAll() {
+        var prefs = NotificationPreferences()
+        prefs.codex5hThresholdAlerts = false
+        #expect(!prefs.codex5hAt15 && !prefs.codex5hAt5 && !prefs.codex5hLimitReached)
+    }
+
+    @Test("setting codex5hThresholdAlerts=true sets all three fields")
+    func aggregateSetTrueSetsAll() {
+        var prefs = NotificationPreferences()
+        prefs.codex5hAt15 = false; prefs.codex5hAt5 = false; prefs.codex5hLimitReached = false
+        prefs.codex5hThresholdAlerts = true
+        #expect(prefs.codex5hAt15 && prefs.codex5hAt5 && prefs.codex5hLimitReached)
+    }
+}

--- a/docs/superpowers/plans/2026-04-02-settings-structural-pass.md
+++ b/docs/superpowers/plans/2026-04-02-settings-structural-pass.md
@@ -1,0 +1,491 @@
+# Settings Structural Pass Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Widen the Settings window to 500pt, reorder sections so Accounts appears before Notifications, give per-service notification sections named headers, collapse 3 per-threshold toggles per window into a single "Threshold alerts" toggle, and normalise any existing mixed-state preferences on launch — all mirrored identically in `NotificationsStepView`.
+
+**Architecture:** All UI changes are confined to two SwiftUI views. The consolidation is backed by computed properties and a `normalizeThresholds()` method added to `NotificationPreferences` (no new stored fields, no encoding changes). The migration fires once in `QuotaViewModel.init()` before any UI renders.
+
+**Tech Stack:** Swift, SwiftUI, Swift Testing (`@Suite` / `@Test` / `#expect`), `xcodegen`
+
+---
+
+## File Map
+
+| File | Role |
+|------|------|
+| `Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift` | Add `normalizeThresholds()` + four aggregate computed properties to `NotificationPreferences` |
+| `Packages/AIQuotaKit/Tests/AIQuotaKitTests/NotificationPreferencesNormalizationTests.swift` | New — unit tests for normalization and aggregate computed properties |
+| `AIQuota/ViewModels/QuotaViewModel.swift` | Call `normalizeThresholds()` in `init()` before UI renders |
+| `AIQuota/Views/SettingsView.swift` | Width → 500pt, section reorder, section titles, aggregate toggles |
+| `AIQuota/Views/Onboarding/Steps/NotificationsStepView.swift` | Same aggregate toggle consolidation as SettingsView |
+
+---
+
+## Task 1 — Add `normalizeThresholds()` and aggregate computed properties to `NotificationPreferences`
+
+**Files:**
+- Modify: `Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift`
+- Create: `Packages/AIQuotaKit/Tests/AIQuotaKitTests/NotificationPreferencesNormalizationTests.swift`
+
+- [ ] **Step 1.1 — Write the failing tests**
+
+Create `Packages/AIQuotaKit/Tests/AIQuotaKitTests/NotificationPreferencesNormalizationTests.swift`:
+
+```swift
+import Testing
+@testable import AIQuotaKit
+
+@Suite("NotificationPreferences normalization")
+struct NotificationPreferencesNormalizationTests {
+
+    // MARK: - normalizeThresholds()
+
+    @Test("all-on groups stay all-on")
+    func allOnUnchanged() {
+        var prefs = NotificationPreferences()
+        // defaults are all true — should be a no-op
+        prefs.normalizeThresholds()
+        #expect(prefs.codex5hAt15 && prefs.codex5hAt5 && prefs.codex5hLimitReached)
+        #expect(prefs.codexAt15 && prefs.codexAt5 && prefs.codexLimitReached)
+        #expect(prefs.claude5hAt15 && prefs.claude5hAt5 && prefs.claude5hLimitReached)
+        #expect(prefs.claude7dAt80 && prefs.claude7dAt95 && prefs.claude7dLimitReached)
+    }
+
+    @Test("all-off groups stay all-off")
+    func allOffUnchanged() {
+        var prefs = NotificationPreferences()
+        prefs.codex5hAt15 = false; prefs.codex5hAt5 = false; prefs.codex5hLimitReached = false
+        prefs.codexAt15 = false; prefs.codexAt5 = false; prefs.codexLimitReached = false
+        prefs.claude5hAt15 = false; prefs.claude5hAt5 = false; prefs.claude5hLimitReached = false
+        prefs.claude7dAt80 = false; prefs.claude7dAt95 = false; prefs.claude7dLimitReached = false
+        prefs.normalizeThresholds()
+        #expect(!prefs.codex5hAt15 && !prefs.codex5hAt5 && !prefs.codex5hLimitReached)
+        #expect(!prefs.claude7dAt80 && !prefs.claude7dAt95 && !prefs.claude7dLimitReached)
+    }
+
+    @Test("mixed group where any=true normalises to all-true")
+    func mixedPartialOnBecomesAllOn() {
+        var prefs = NotificationPreferences()
+        // Only one of three is on in the Codex 5h group
+        prefs.codex5hAt15 = false
+        prefs.codex5hAt5 = false
+        prefs.codex5hLimitReached = true   // one left on
+        prefs.normalizeThresholds()
+        #expect(prefs.codex5hAt15)
+        #expect(prefs.codex5hAt5)
+        #expect(prefs.codex5hLimitReached)
+    }
+
+    @Test("mixed group where any=true normalises independently per group")
+    func eachGroupNormalisedIndependently() {
+        var prefs = NotificationPreferences()
+        // Codex weekly: only limit reached is on — should become all-on
+        prefs.codexAt15 = false; prefs.codexAt5 = false; prefs.codexLimitReached = true
+        // Claude 7d: all off — should stay all-off
+        prefs.claude7dAt80 = false; prefs.claude7dAt95 = false; prefs.claude7dLimitReached = false
+        prefs.normalizeThresholds()
+        #expect(prefs.codexAt15 && prefs.codexAt5 && prefs.codexLimitReached)
+        #expect(!prefs.claude7dAt80 && !prefs.claude7dAt95 && !prefs.claude7dLimitReached)
+    }
+
+    // MARK: - Aggregate computed properties
+
+    @Test("codex5hThresholdAlerts is true when all three are true")
+    func aggregateAllOnIsTrue() {
+        let prefs = NotificationPreferences()
+        #expect(prefs.codex5hThresholdAlerts == true)
+    }
+
+    @Test("codex5hThresholdAlerts is false when all three are false")
+    func aggregateAllOffIsFalse() {
+        var prefs = NotificationPreferences()
+        prefs.codex5hAt15 = false; prefs.codex5hAt5 = false; prefs.codex5hLimitReached = false
+        #expect(prefs.codex5hThresholdAlerts == false)
+    }
+
+    @Test("setting codex5hThresholdAlerts=false clears all three fields")
+    func aggregateSetFalseClearsAll() {
+        var prefs = NotificationPreferences()
+        prefs.codex5hThresholdAlerts = false
+        #expect(!prefs.codex5hAt15 && !prefs.codex5hAt5 && !prefs.codex5hLimitReached)
+    }
+
+    @Test("setting codex5hThresholdAlerts=true sets all three fields")
+    func aggregateSetTrueSetsAll() {
+        var prefs = NotificationPreferences()
+        prefs.codex5hAt15 = false; prefs.codex5hAt5 = false; prefs.codex5hLimitReached = false
+        prefs.codex5hThresholdAlerts = true
+        #expect(prefs.codex5hAt15 && prefs.codex5hAt5 && prefs.codex5hLimitReached)
+    }
+}
+```
+
+- [ ] **Step 1.2 — Run to confirm tests fail**
+
+```bash
+swift test --package-path Packages/AIQuotaKit --filter NotificationPreferencesNormalization 2>&1 | grep -E 'error:|passed|failed|Test run'
+```
+
+Expected: compile error — `normalizeThresholds` and `codex5hThresholdAlerts` do not exist yet.
+
+- [ ] **Step 1.3 — Add the implementation to `NotificationPreferences`**
+
+In `Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift`, after the `init(from decoder:)` block and before the closing `}` of `NotificationPreferences`, add:
+
+```swift
+    // MARK: - Aggregate computed properties (UI consolidation)
+    // Each property covers one window type's threshold alerts (at-%, limit reached).
+    // Reads true if any underlying field is on; writes all three simultaneously.
+
+    public var codex5hThresholdAlerts: Bool {
+        get { codex5hAt15 || codex5hAt5 || codex5hLimitReached }
+        set { codex5hAt15 = newValue; codex5hAt5 = newValue; codex5hLimitReached = newValue }
+    }
+
+    public var codexWeeklyThresholdAlerts: Bool {
+        get { codexAt15 || codexAt5 || codexLimitReached }
+        set { codexAt15 = newValue; codexAt5 = newValue; codexLimitReached = newValue }
+    }
+
+    public var claude5hThresholdAlerts: Bool {
+        get { claude5hAt15 || claude5hAt5 || claude5hLimitReached }
+        set { claude5hAt15 = newValue; claude5hAt5 = newValue; claude5hLimitReached = newValue }
+    }
+
+    public var claude7dThresholdAlerts: Bool {
+        get { claude7dAt80 || claude7dAt95 || claude7dLimitReached }
+        set { claude7dAt80 = newValue; claude7dAt95 = newValue; claude7dLimitReached = newValue }
+    }
+
+    // MARK: - Migration
+
+    /// Normalises any threshold group where the three underlying booleans are not all
+    /// the same value. Mixed groups are resolved to their OR result (any=true → all-true).
+    /// Call once on app launch before UI renders; subsequent interactions use the
+    /// aggregate computed properties above which always write all three uniformly.
+    public mutating func normalizeThresholds() {
+        func normalize(_ a: inout Bool, _ b: inout Bool, _ c: inout Bool) {
+            let resolved = a || b || c
+            if a != resolved || b != resolved || c != resolved {
+                a = resolved; b = resolved; c = resolved
+            }
+        }
+        normalize(&codex5hAt15,  &codex5hAt5,  &codex5hLimitReached)
+        normalize(&codexAt15,    &codexAt5,    &codexLimitReached)
+        normalize(&claude5hAt15, &claude5hAt5, &claude5hLimitReached)
+        normalize(&claude7dAt80, &claude7dAt95, &claude7dLimitReached)
+    }
+```
+
+- [ ] **Step 1.4 — Run tests to confirm they pass**
+
+```bash
+swift test --package-path Packages/AIQuotaKit --filter NotificationPreferencesNormalization 2>&1 | grep -E 'passed|failed|Test run'
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 1.5 — Run full test suite to confirm no regressions**
+
+```bash
+swift test --package-path Packages/AIQuotaKit 2>&1 | tail -8
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 1.6 — Commit**
+
+```bash
+git add Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift \
+        Packages/AIQuotaKit/Tests/AIQuotaKitTests/NotificationPreferencesNormalizationTests.swift
+git commit -m "feat: add threshold normalisation and aggregate computed properties to NotificationPreferences"
+```
+
+---
+
+## Task 2 — Call `normalizeThresholds()` in `QuotaViewModel.init()`
+
+**Files:**
+- Modify: `AIQuota/ViewModels/QuotaViewModel.swift` (around line 210, just before the notification permission request)
+
+- [ ] **Step 2.1 — Add the normalization call in `init()`**
+
+In `QuotaViewModel.init()`, after the `// Load cached data immediately` block (around line 162–164) and before the `// Observe coordinator state streams` comment, insert:
+
+```swift
+        // Normalise any mixed per-threshold notification state from pre-consolidation builds.
+        // OR-resolves each group (any=true → all-true) so aggregate toggles always see
+        // a clean on/off state from the first render.
+        let preNorm = settings
+        settings.notifications.normalizeThresholds()
+        if settings != preNorm { SharedDefaults.saveSettings(settings) }
+```
+
+The `preNorm` comparison avoids a redundant write for users who have never had mixed state (the common case).
+
+- [ ] **Step 2.2 — Build to confirm compilation**
+
+```bash
+xcodegen generate && xcodebuild build -scheme AIQuota -destination 'platform=macOS' 2>&1 | grep -E '^.*error:|BUILD (SUCCEEDED|FAILED)'
+```
+
+Expected: `BUILD SUCCEEDED`
+
+- [ ] **Step 2.3 — Commit**
+
+```bash
+git add AIQuota/ViewModels/QuotaViewModel.swift
+git commit -m "feat: normalise mixed notification threshold state on launch"
+```
+
+---
+
+## Task 3 — Restructure `SettingsView`
+
+**Files:**
+- Modify: `AIQuota/Views/SettingsView.swift`
+
+Three sub-changes: (a) width + section reorder, (b) section titles + aggregate toggles.
+
+### 3a — Width and section reorder
+
+- [ ] **Step 3a.1 — Widen to 500pt**
+
+Find `.frame(width: 400)` (near the bottom of `body`) and change to `.frame(width: 500)`.
+
+- [ ] **Step 3a.2 — Move Accounts section above Notifications**
+
+Cut the entire `// MARK: Accounts` section block (lines ~124–139 in current file):
+
+```swift
+            // MARK: Accounts
+            Section("Accounts") {
+                LabeledContent("Codex") {
+                    if viewModel.isCodexAuthenticated {
+                        Button("Sign Out", role: .destructive) { viewModel.signOut() }
+                    } else {
+                        Button("Sign In") { Task { await viewModel.signIn() } }
+                    }
+                }
+                LabeledContent("Claude Code") {
+                    if viewModel.isClaudeAuthenticated {
+                        Button("Sign Out", role: .destructive) { viewModel.signOutClaude() }
+                    } else {
+                        Button("Sign In") { Task { await viewModel.signInClaude() } }
+                    }
+                }
+            }
+```
+
+Paste it immediately after the closing `}` of the `// MARK: General` section (after line ~41).
+
+### 3b — Named section titles + aggregate toggles
+
+- [ ] **Step 3b.1 — Add a string title to the Codex notification section**
+
+The Codex section currently opens with an anonymous `Section {`. Change it to `Section("Codex") {`.
+
+- [ ] **Step 3b.2 — Replace per-threshold Codex toggles with aggregate bindings**
+
+Inside the Codex section's expanded block, replace:
+
+```swift
+                        notifSubHeader("5-hour window")
+                        Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.codex5hAt15)
+                        Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.codex5hAt5)
+                        Toggle("Limit reached",           isOn: $vm.settings.notifications.codex5hLimitReached)
+                        Toggle("Window reset",            isOn: $vm.settings.notifications.codex5hReset)
+
+                        notifSubHeader("Weekly usage")
+                        Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.codexAt15)
+                        Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.codexAt5)
+                        Toggle("Limit reached",           isOn: $vm.settings.notifications.codexLimitReached)
+                        Toggle("Weekly reset",            isOn: $vm.settings.notifications.codexReset)
+```
+
+With:
+
+```swift
+                        notifSubHeader("5-hour window")
+                        Toggle("Threshold alerts", isOn: $vm.settings.notifications.codex5hThresholdAlerts)
+                        Toggle("Window reset",     isOn: $vm.settings.notifications.codex5hReset)
+
+                        notifSubHeader("Weekly usage")
+                        Toggle("Threshold alerts", isOn: $vm.settings.notifications.codexWeeklyThresholdAlerts)
+                        Toggle("Weekly reset",     isOn: $vm.settings.notifications.codexReset)
+```
+
+- [ ] **Step 3b.3 — Add a string title to the Claude notification section**
+
+Change the Claude section's `Section {` to `Section("Claude Code") {`.
+
+- [ ] **Step 3b.4 — Replace per-threshold Claude toggles with aggregate bindings**
+
+Inside the Claude section's expanded block, replace:
+
+```swift
+                        notifSubHeader("5-hour window")
+                        Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.claude5hAt15)
+                        Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.claude5hAt5)
+                        Toggle("Limit reached",           isOn: $vm.settings.notifications.claude5hLimitReached)
+                        Toggle("Window reset",            isOn: $vm.settings.notifications.claude5hReset)
+
+                        notifSubHeader("7-day window")
+                        Toggle("80% used (high)",         isOn: $vm.settings.notifications.claude7dAt80)
+                        Toggle("95% used (critical)",     isOn: $vm.settings.notifications.claude7dAt95)
+                        Toggle("Limit reached",           isOn: $vm.settings.notifications.claude7dLimitReached)
+                        Toggle("Period reset",            isOn: $vm.settings.notifications.claude7dReset)
+```
+
+With:
+
+```swift
+                        notifSubHeader("5-hour window")
+                        Toggle("Threshold alerts", isOn: $vm.settings.notifications.claude5hThresholdAlerts)
+                        Toggle("Window reset",     isOn: $vm.settings.notifications.claude5hReset)
+
+                        notifSubHeader("7-day window")
+                        Toggle("Threshold alerts", isOn: $vm.settings.notifications.claude7dThresholdAlerts)
+                        Toggle("Period reset",     isOn: $vm.settings.notifications.claude7dReset)
+```
+
+- [ ] **Step 3b.5 — Remove the stale per-service animation modifiers**
+
+The following two `.animation` modifiers on the `Form` are no longer needed (they animated the expansion of the individual toggles, which are now gone). Remove them:
+
+```swift
+        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: viewModel.settings.notifications.codexEnabled)
+        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: viewModel.settings.notifications.claudeEnabled)
+```
+
+The master `.animation` keyed on `notifSectionsEnabled` stays — it still animates the section disable/fade.
+
+> **Note:** The `@Bindable` binding path `$vm.settings.notifications.codex5hThresholdAlerts` works because `NotificationPreferences` is a struct nested inside `AppSettings` which is `@Observable`-tracked through `@Bindable var vm`. The computed property setter mutates the struct in place, which triggers observation. No additional binding wrappers needed.
+
+- [ ] **Step 3b.6 — Build to confirm compilation**
+
+```bash
+xcodebuild build -scheme AIQuota -destination 'platform=macOS' 2>&1 | grep -E '^.*error:|BUILD (SUCCEEDED|FAILED)'
+```
+
+Expected: `BUILD SUCCEEDED`
+
+- [ ] **Step 3b.7 — Commit**
+
+```bash
+git add AIQuota/Views/SettingsView.swift
+git commit -m "feat: settings structural pass — 500pt width, reorder sections, named notif sections, aggregate threshold toggles"
+```
+
+---
+
+## Task 4 — Mirror consolidation in `NotificationsStepView`
+
+**Files:**
+- Modify: `AIQuota/Views/Onboarding/Steps/NotificationsStepView.swift`
+
+- [ ] **Step 4.1 — Add a string title to the Codex section**
+
+Change `Section {` (Codex block, around line 51) to `Section("Codex") {`.
+
+- [ ] **Step 4.2 — Replace per-threshold Codex toggles with aggregate bindings**
+
+Replace:
+
+```swift
+                            subHeader("5-hour window")
+                            Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.codex5hAt15)
+                            Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.codex5hAt5)
+                            Toggle("Limit reached",           isOn: $vm.settings.notifications.codex5hLimitReached)
+                            Toggle("Window reset",            isOn: $vm.settings.notifications.codex5hReset)
+
+                            subHeader("Weekly usage")
+                            Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.codexAt15)
+                            Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.codexAt5)
+                            Toggle("Limit reached",           isOn: $vm.settings.notifications.codexLimitReached)
+                            Toggle("Weekly reset",            isOn: $vm.settings.notifications.codexReset)
+```
+
+With:
+
+```swift
+                            subHeader("5-hour window")
+                            Toggle("Threshold alerts", isOn: $vm.settings.notifications.codex5hThresholdAlerts)
+                            Toggle("Window reset",     isOn: $vm.settings.notifications.codex5hReset)
+
+                            subHeader("Weekly usage")
+                            Toggle("Threshold alerts", isOn: $vm.settings.notifications.codexWeeklyThresholdAlerts)
+                            Toggle("Weekly reset",     isOn: $vm.settings.notifications.codexReset)
+```
+
+- [ ] **Step 4.3 — Add a string title to the Claude section**
+
+Change `Section {` (Claude block, around line 75) to `Section("Claude Code") {`.
+
+- [ ] **Step 4.4 — Replace per-threshold Claude toggles with aggregate bindings**
+
+Replace:
+
+```swift
+                            subHeader("5-hour window")
+                            Toggle("Less than 15% remaining", isOn: $vm.settings.notifications.claude5hAt15)
+                            Toggle("Less than 5% remaining",  isOn: $vm.settings.notifications.claude5hAt5)
+                            Toggle("Limit reached",           isOn: $vm.settings.notifications.claude5hLimitReached)
+                            Toggle("Window reset",            isOn: $vm.settings.notifications.claude5hReset)
+
+                            subHeader("7-day window")
+                            Toggle("80% used (high)",         isOn: $vm.settings.notifications.claude7dAt80)
+                            Toggle("95% used (critical)",     isOn: $vm.settings.notifications.claude7dAt95)
+                            Toggle("Limit reached",           isOn: $vm.settings.notifications.claude7dLimitReached)
+                            Toggle("Period reset",            isOn: $vm.settings.notifications.claude7dReset)
+```
+
+With:
+
+```swift
+                            subHeader("5-hour window")
+                            Toggle("Threshold alerts", isOn: $vm.settings.notifications.claude5hThresholdAlerts)
+                            Toggle("Window reset",     isOn: $vm.settings.notifications.claude5hReset)
+
+                            subHeader("7-day window")
+                            Toggle("Threshold alerts", isOn: $vm.settings.notifications.claude7dThresholdAlerts)
+                            Toggle("Period reset",     isOn: $vm.settings.notifications.claude7dReset)
+```
+
+- [ ] **Step 4.5 — Remove the stale per-service animation modifiers**
+
+Remove from the `Form`:
+
+```swift
+        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: viewModel.settings.notifications.codexEnabled)
+        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: viewModel.settings.notifications.claudeEnabled)
+```
+
+- [ ] **Step 4.6 — Build to confirm compilation**
+
+```bash
+xcodebuild build -scheme AIQuota -destination 'platform=macOS' 2>&1 | grep -E '^.*error:|BUILD (SUCCEEDED|FAILED)'
+```
+
+Expected: `BUILD SUCCEEDED`
+
+- [ ] **Step 4.7 — Commit**
+
+```bash
+git add AIQuota/Views/Onboarding/Steps/NotificationsStepView.swift
+git commit -m "feat: mirror aggregate threshold toggles in NotificationsStepView"
+```
+
+---
+
+## Manual Smoke Test
+
+After all tasks are complete, launch the app and verify:
+
+1. Settings window opens at ~500pt wide (visibly wider than before)
+2. Accounts section appears second, before Notifications
+3. With a service enrolled and notifications enabled, the per-service section shows a named header ("Codex" or "Claude Code")
+4. Expanding a service shows 2 sub-headers × 2 rows each (not 2 sub-headers × 4 rows)
+5. Toggling "Threshold alerts" off and back on sets all three underlying fields correctly — verify by checking that notifications actually fire/suppress appropriately, or inspect via a breakpoint in `normalizeThresholds`
+6. Open "Guided Setup…" → advance to the Notifications step — confirm the same consolidated layout appears there

--- a/docs/superpowers/specs/2026-04-02-settings-structural-pass-design.md
+++ b/docs/superpowers/specs/2026-04-02-settings-structural-pass-design.md
@@ -14,6 +14,8 @@ The Settings window has two interrelated issues:
 
 2. **Notification section lacks hierarchy.** The master toggle, permission status, per-service toggles, sub-window sub-headers, and 16 individual threshold toggles all render at the same visual depth. There is no clear parent-child relationship.
 
+Additionally, `NotificationsStepView` (the onboarding notifications step) is a structural copy of the Settings notification section and exposes the same per-threshold individual toggles. Because "Guided Setup…" can be replayed at any time from Settings, leaving it with individual toggles creates two editors for the same data with conflicting semantics.
+
 ---
 
 ## Design
@@ -71,6 +73,8 @@ Row count per service (when expanded): **11 → 7**
 
 Total notification sub-rows with both services enrolled: **22 → 14**.
 
+The same hierarchy is applied identically in `NotificationsStepView` so both surfaces stay semantically consistent.
+
 ### Threshold alerts toggle — field mapping
 
 No new model fields are added. `NotificationPreferences` retains all existing fine-grained booleans. The consolidated "Threshold alerts" toggle:
@@ -91,11 +95,18 @@ Exact field mappings per service and window:
 | Claude | 7-day | Threshold alerts | `claude7dAt80`, `claude7dAt95`, `claude7dLimitReached` |
 | Claude | 7-day | Period reset | `claude7dReset` |
 
-This preserves stored preferences across app versions. Users who had a mixed on/off state see "on" in the consolidated toggle; their next interaction normalises all three to the same value. This is an acceptable one-time reset given how rarely these are tuned.
+### Mixed-state migration
+
+On app launch, before any UI renders, `QuotaViewModel` normalizes any threshold groups that have mixed values: if the three underlying booleans in a group are not all the same value, they are normalized to their OR result and saved. This is a one-time write for any user who had mixed per-threshold state.
+
+This ensures:
+- The aggregate toggle always reads a clean on/off state — no hidden partial state on first render
+- Toggling off sets all three to `false`; toggling on sets all three to `true` — no silent scope widening
+- A clean path exists if granular controls are ever reintroduced later, because per-group consistency is a guaranteed invariant from this version onward
 
 ### Sub-header rendering
 
-Sub-headers use `.font(.footnote.weight(.semibold))` and `.foregroundStyle(.secondary)` with `.listRowBackground(Color.clear)` — matching the existing `notifSubHeader` helper already in the view. No changes to `notifSubHeader`.
+Sub-headers use `.font(.footnote.weight(.semibold))` and `.foregroundStyle(.secondary)` with `.listRowBackground(Color.clear)` — matching the existing `notifSubHeader`/`subHeader` helpers already in both views. No changes to those helpers.
 
 ---
 
@@ -104,7 +115,7 @@ Sub-headers use `.font(.footnote.weight(.semibold))` and `.foregroundStyle(.seco
 - No changes to `NotificationPreferences` model fields or encoding keys
 - No changes to `NotificationManager` firing logic
 - No tab-based or sidebar navigation
-- No changes to the About footer content or Onboarding section behaviour
+- No changes to the About footer content or Onboarding section content/behaviour
 
 ---
 
@@ -113,5 +124,5 @@ Sub-headers use `.font(.footnote.weight(.semibold))` and `.foregroundStyle(.seco
 | File | Change |
 |------|--------|
 | `AIQuota/Views/SettingsView.swift` | Width (400→500), section reorder, per-service section titles, threshold toggle consolidation |
-
-No other files require changes.
+| `AIQuota/Views/Onboarding/Steps/NotificationsStepView.swift` | Same threshold toggle consolidation as SettingsView |
+| `AIQuota/ViewModels/QuotaViewModel.swift` (or equivalent settings load path) | Mixed-state normalization on launch |

--- a/docs/superpowers/specs/2026-04-02-settings-structural-pass-design.md
+++ b/docs/superpowers/specs/2026-04-02-settings-structural-pass-design.md
@@ -10,7 +10,7 @@
 
 The Settings window has two interrelated issues:
 
-1. **Too narrow and too tall.** At 400pt wide, the window is unusually cramped for a macOS desktop app. With both services enrolled, the form renders ~28 rows across 8 sections, requiring significant scrolling.
+1. **Too narrow and too tall.** At 400pt wide, the window is unusually cramped for a macOS desktop app. With both services enrolled, the form renders many rows across 8 sections, requiring significant scrolling.
 
 2. **Notification section lacks hierarchy.** The master toggle, permission status, per-service toggles, sub-window sub-headers, and 16 individual threshold toggles all render at the same visual depth. There is no clear parent-child relationship.
 
@@ -24,53 +24,78 @@ Widen from **400pt → 500pt**. This is still narrower than System Settings (~66
 
 ### Section ordering
 
+The full ordered list of `Section` blocks, top to bottom:
+
 | # | Section | Change |
 |---|---------|--------|
 | 1 | General | No change |
 | 2 | Accounts | **Moved up** from near bottom |
-| 3 | Notifications | Restructured (see below) |
-| 4 | Updates | No change |
-| 5 | Onboarding | No change |
-| 6 | About footer | No change |
+| 3 | Notifications (master) | Unchanged content |
+| 4 | Codex notification section | Restructured — see below |
+| 5 | Claude Code notification section | Restructured — see below |
+| 6 | "No services enrolled" fallback | No change |
+| 7 | Updates | No change |
+| 8 | Onboarding | No change |
+| 9 | About footer | No change |
 
 Accounts moves above Notifications because it gates whether per-service notification sections appear at all. Onboarding and About stay at the bottom — they are rarely touched.
 
 ### Notification hierarchy
 
-The master "Notifications" section is unchanged: enable toggle + `NotificationStatusRow`.
+The master "Notifications" section (section 3) is unchanged: enable toggle + `NotificationStatusRow`.
 
-Each enrolled service gets a named section with a three-level hierarchy:
+Each enrolled service gets a named section. The per-service sections currently use anonymous `Section { ... }` blocks with no title. **These gain a string title matching the service display name** (`Section("Codex")`, `Section("Claude Code")`).
+
+Within each named section:
 
 ```
-Section("Codex")                                    ← named section header
+Section("Codex")                                    ← new: named section header
   [logo] Codex  ─────────────────────  [toggle]     ← service master switch
 
   (inline expansion when service toggle is ON)
 
-  5-HOUR WINDOW                                     ← sub-header (footnote weight, secondary color)
-    Threshold alerts               [toggle]         ← drives: at15 + at5 + limitReached
+  5-hour window                                     ← sub-header (footnote weight, secondary)
+    Threshold alerts               [toggle]         ← see field mapping below
     Window reset                   [toggle]
 
-  WEEKLY USAGE  (Codex) / 7-DAY WINDOW (Claude)    ← sub-header
-    Threshold alerts               [toggle]         ← drives: weekly/7d thresholds
-    [Period] reset                 [toggle]
+  Weekly usage                                      ← sub-header (Codex); "7-day window" for Claude
+    Threshold alerts               [toggle]         ← see field mapping below
+    Weekly reset                   [toggle]         ← "Period reset" for Claude
 ```
 
-Row count per service: **8 → 5** (service toggle + 2 sub-headers + 4 toggles).
-Total notification rows with both services enrolled: **~18 → ~12**.
+Sub-header text is **retained verbatim** from the current code: `"5-hour window"`, `"Weekly usage"` (Codex), `"7-day window"` (Claude).
 
-### Threshold alerts toggle — data model mapping
+Row count per service (when expanded): **11 → 7**
+- Before: service toggle + 2 sub-headers + 8 threshold/reset toggles = 11
+- After: service toggle + 2 sub-headers + 4 toggles = 7
 
-No new model fields are added. `NotificationPreferences` retains all existing fine-grained booleans. The consolidated "Threshold alerts" toggle in the UI:
+Total notification sub-rows with both services enrolled: **22 → 14**.
 
-- **Reads:** `on` if any of the underlying fields are `true` (`at15 || at5 || limitReached`)
+### Threshold alerts toggle — field mapping
+
+No new model fields are added. `NotificationPreferences` retains all existing fine-grained booleans. The consolidated "Threshold alerts" toggle:
+
+- **Reads:** `on` if any of the underlying fields are `true` (OR of all three)
 - **Writes:** sets all three underlying fields to the new value simultaneously
+
+Exact field mappings per service and window:
+
+| Section | Window | Toggle | Fields driven |
+|---------|--------|--------|---------------|
+| Codex | 5-hour | Threshold alerts | `codex5hAt15`, `codex5hAt5`, `codex5hLimitReached` |
+| Codex | 5-hour | Window reset | `codex5hReset` |
+| Codex | Weekly | Threshold alerts | `codexAt15`, `codexAt5`, `codexLimitReached` |
+| Codex | Weekly | Weekly reset | `codexReset` |
+| Claude | 5-hour | Threshold alerts | `claude5hAt15`, `claude5hAt5`, `claude5hLimitReached` |
+| Claude | 5-hour | Window reset | `claude5hReset` |
+| Claude | 7-day | Threshold alerts | `claude7dAt80`, `claude7dAt95`, `claude7dLimitReached` |
+| Claude | 7-day | Period reset | `claude7dReset` |
 
 This preserves stored preferences across app versions. Users who had a mixed on/off state see "on" in the consolidated toggle; their next interaction normalises all three to the same value. This is an acceptable one-time reset given how rarely these are tuned.
 
 ### Sub-header rendering
 
-Sub-headers (`5-HOUR WINDOW`, `WEEKLY USAGE`, etc.) use `.font(.footnote.weight(.semibold))` and `.foregroundStyle(.secondary)` with `.listRowBackground(Color.clear)` — matching the existing `notifSubHeader` helper already in the view.
+Sub-headers use `.font(.footnote.weight(.semibold))` and `.foregroundStyle(.secondary)` with `.listRowBackground(Color.clear)` — matching the existing `notifSubHeader` helper already in the view. No changes to `notifSubHeader`.
 
 ---
 
@@ -87,6 +112,6 @@ Sub-headers (`5-HOUR WINDOW`, `WEEKLY USAGE`, etc.) use `.font(.footnote.weight(
 
 | File | Change |
 |------|--------|
-| `AIQuota/Views/SettingsView.swift` | Width, section reorder, notification hierarchy, threshold toggle helpers |
+| `AIQuota/Views/SettingsView.swift` | Width (400→500), section reorder, per-service section titles, threshold toggle consolidation |
 
 No other files require changes.

--- a/docs/superpowers/specs/2026-04-02-settings-structural-pass-design.md
+++ b/docs/superpowers/specs/2026-04-02-settings-structural-pass-design.md
@@ -1,0 +1,92 @@
+# Settings Structural Pass — Design Spec
+
+**Date:** 2026-04-02
+**Status:** Approved
+**Roadmap item:** Settings is cramped — too much scrolling, notifications lack hierarchy; needs a structural pass
+
+---
+
+## Problem
+
+The Settings window has two interrelated issues:
+
+1. **Too narrow and too tall.** At 400pt wide, the window is unusually cramped for a macOS desktop app. With both services enrolled, the form renders ~28 rows across 8 sections, requiring significant scrolling.
+
+2. **Notification section lacks hierarchy.** The master toggle, permission status, per-service toggles, sub-window sub-headers, and 16 individual threshold toggles all render at the same visual depth. There is no clear parent-child relationship.
+
+---
+
+## Design
+
+### Window width
+
+Widen from **400pt → 500pt**. This is still narrower than System Settings (~668pt) but appropriate for this app's content volume. It gives segmented pickers and labeled rows room to breathe without making toggle rows look sparse.
+
+### Section ordering
+
+| # | Section | Change |
+|---|---------|--------|
+| 1 | General | No change |
+| 2 | Accounts | **Moved up** from near bottom |
+| 3 | Notifications | Restructured (see below) |
+| 4 | Updates | No change |
+| 5 | Onboarding | No change |
+| 6 | About footer | No change |
+
+Accounts moves above Notifications because it gates whether per-service notification sections appear at all. Onboarding and About stay at the bottom — they are rarely touched.
+
+### Notification hierarchy
+
+The master "Notifications" section is unchanged: enable toggle + `NotificationStatusRow`.
+
+Each enrolled service gets a named section with a three-level hierarchy:
+
+```
+Section("Codex")                                    ← named section header
+  [logo] Codex  ─────────────────────  [toggle]     ← service master switch
+
+  (inline expansion when service toggle is ON)
+
+  5-HOUR WINDOW                                     ← sub-header (footnote weight, secondary color)
+    Threshold alerts               [toggle]         ← drives: at15 + at5 + limitReached
+    Window reset                   [toggle]
+
+  WEEKLY USAGE  (Codex) / 7-DAY WINDOW (Claude)    ← sub-header
+    Threshold alerts               [toggle]         ← drives: weekly/7d thresholds
+    [Period] reset                 [toggle]
+```
+
+Row count per service: **8 → 5** (service toggle + 2 sub-headers + 4 toggles).
+Total notification rows with both services enrolled: **~18 → ~12**.
+
+### Threshold alerts toggle — data model mapping
+
+No new model fields are added. `NotificationPreferences` retains all existing fine-grained booleans. The consolidated "Threshold alerts" toggle in the UI:
+
+- **Reads:** `on` if any of the underlying fields are `true` (`at15 || at5 || limitReached`)
+- **Writes:** sets all three underlying fields to the new value simultaneously
+
+This preserves stored preferences across app versions. Users who had a mixed on/off state see "on" in the consolidated toggle; their next interaction normalises all three to the same value. This is an acceptable one-time reset given how rarely these are tuned.
+
+### Sub-header rendering
+
+Sub-headers (`5-HOUR WINDOW`, `WEEKLY USAGE`, etc.) use `.font(.footnote.weight(.semibold))` and `.foregroundStyle(.secondary)` with `.listRowBackground(Color.clear)` — matching the existing `notifSubHeader` helper already in the view.
+
+---
+
+## Out of scope
+
+- No changes to `NotificationPreferences` model fields or encoding keys
+- No changes to `NotificationManager` firing logic
+- No tab-based or sidebar navigation
+- No changes to the About footer content or Onboarding section behaviour
+
+---
+
+## Files affected
+
+| File | Change |
+|------|--------|
+| `AIQuota/Views/SettingsView.swift` | Width, section reorder, notification hierarchy, threshold toggle helpers |
+
+No other files require changes.


### PR DESCRIPTION
## Summary

- **Window width 400→500pt** — gives segmented pickers and labeled rows room to breathe
- **Accounts section moved above Notifications** — gates per-service notification sections so it logically precedes them
- **Named notification sections** — per-service sections gain `Section("Codex")` / `Section("Claude Code")` titles; redundant bold service-name label removed from the service row helper
- **Aggregate threshold toggles** — 16 individual per-threshold toggles (`< 15%`, `< 5%`, `Limit reached`) collapsed to a single `Threshold alerts` toggle per window type, applied identically in both `SettingsView` and `NotificationsStepView`
- **Launch-time normalization** — `normalizeThresholds()` in `QuotaViewModel.init()` resolves any mixed-state threshold preferences from before this change (any-true → all-true), so the aggregate toggle always shows a clean on/off state from the first render

## Test Plan

- [ ] Build and run on Mac; open Settings — window is visibly wider (~500pt)
- [ ] Accounts section appears second (below General, above Notifications)
- [ ] With a service enrolled and notifications enabled, per-service section shows named header ("Codex" or "Claude Code") with logo + toggle, no duplicate service name label
- [ ] Expanding a service shows 2 sub-headers × 2 rows each (Threshold alerts + reset per window type)
- [ ] Toggling "Threshold alerts" off sets all three underlying fields to false; toggling back on sets all three to true
- [ ] Open Guided Setup → Notifications step — same consolidated layout appears
- [ ] 52 unit tests pass: `swift test --package-path Packages/AIQuotaKit`