### PR TITLE
Set default Settings window size to 500×720

### DIFF
--- a/AIQuota/AIQuotaApp.swift
+++ b/AIQuota/AIQuotaApp.swift
@@ -65,6 +65,7 @@ struct AIQuotaApp: App {
                 .environment(viewModel)
                 .environment(UpdaterViewModel(updater: updaterController.updater))
         }
+        .defaultSize(width: 500, height: 720)
     }
 
     // MARK: - Menu bar gauge selection


### PR DESCRIPTION
## Summary
- Adds `.defaultSize(width: 500, height: 720)` to the Settings scene so new installs open at a comfortable height that fits all sections without scrolling
- Only affects users with no previously saved window size — existing users keep their saved dimensions