### PR TITLE
Fix Settings window size — enforce 500×600, ignore saved state

### DIFF
--- a/AIQuota/AIQuotaApp.swift
+++ b/AIQuota/AIQuotaApp.swift
@@ -66,6 +66,7 @@ struct AIQuotaApp: App {
                 .environment(UpdaterViewModel(updater: updaterController.updater))
         }
         .defaultSize(width: 500, height: 720)
+        .windowResizability(.contentSize)
     }
 
     // MARK: - Menu bar gauge selection

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -173,7 +173,7 @@ struct SettingsView: View {
         }
         .id(formID)
         .formStyle(.grouped)
-        .frame(width: 500, height: 600)
+        .frame(width: 500, height: 700)
         .navigationTitle("Settings")
         .task { await checkNotifPermission() }
         // macOS keeps the Settings window alive between opens (just hides it),

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -173,7 +173,7 @@ struct SettingsView: View {
         }
         .id(formID)
         .formStyle(.grouped)
-        .frame(width: 500)
+        .frame(width: 500, height: 600)
         .navigationTitle("Settings")
         .task { await checkNotifPermission() }
         // macOS keeps the Settings window alive between opens (just hides it),


### PR DESCRIPTION
## Summary
- Adds `.windowResizability(.contentSize)` to the Settings scene so macOS ignores any saved window frame from older builds
- Changes the Form frame from `width: 500` to `width: 500, height: 600` so the window has a fixed, predictable size
- Content scrolls within the fixed frame — nothing is clipped

Fixes the window appearing tiny and non-resizable for users upgrading from builds where the Settings window was shorter.