### PR TITLE
Fix Settings window size — imperatively enforce 500×700

### DIFF
--- a/AIQuota/AIQuotaApp.swift
+++ b/AIQuota/AIQuotaApp.swift
@@ -66,6 +66,7 @@ struct AIQuotaApp: App {
                 .environment(UpdaterViewModel(updater: updaterController.updater))
         }
         .defaultSize(width: 500, height: 720)
+        .windowResizability(.contentSize)
     }
 
     // MARK: - Menu bar gauge selection

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -236,15 +236,30 @@ struct SettingsView: View {
     }
 }
 
-// MARK: - Window level helper
+// MARK: - Window level + size enforcer
 
 private struct FloatingWindowElevator: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
-        DispatchQueue.main.async { view.window?.level = .floating }
+        DispatchQueue.main.async { Self.configure(view.window) }
         return view
     }
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async { Self.configure(nsView.window) }
+    }
+
+    private static func configure(_ window: NSWindow?) {
+        guard let window else { return }
+        window.level = .floating
+        // Override any macOS-restored frame — saved sizes from older builds
+        // would otherwise produce a window that's too small to scroll into.
+        let size = NSSize(width: 500, height: 700)
+        window.minSize = size
+        window.maxSize = size
+        if window.frame.size != size {
+            window.setContentSize(size)
+        }
+    }
 }
 
 // MARK: - Notification Status

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -173,7 +173,7 @@ struct SettingsView: View {
         }
         .id(formID)
         .formStyle(.grouped)
-        .frame(width: 500, height: 600)
+        .frame(width: 500, height: 700)
         .navigationTitle("Settings")
         .task { await checkNotifPermission() }
         // macOS keeps the Settings window alive between opens (just hides it),

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -173,7 +173,7 @@ struct SettingsView: View {
         }
         .id(formID)
         .formStyle(.grouped)
-        .frame(width: 500)
+        .frame(width: 500, height: 600)
         .navigationTitle("Settings")
         .task { await checkNotifPermission() }
         // macOS keeps the Settings window alive between opens (just hides it),


### PR DESCRIPTION
## Summary
- Extends `FloatingWindowElevator` to also set `minSize`, `maxSize`, and `contentSize` on every SwiftUI update pass
- This overrides whatever frame macOS saved from older builds, ensuring the window is always 500×700 regardless of prior state
- Fixes the window appearing too small to scroll after upgrading from earlier versions