### PR TITLE
chore: bump to 1.9.10, update README

### DIFF
--- a/AIQuota/AIQuotaApp.swift
+++ b/AIQuota/AIQuotaApp.swift
@@ -66,6 +66,7 @@ struct AIQuotaApp: App {
                 .environment(UpdaterViewModel(updater: updaterController.updater))
         }
         .defaultSize(width: 500, height: 720)
+        .windowResizability(.contentSize)
     }
 
     // MARK: - Menu bar gauge selection

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -236,15 +236,30 @@ struct SettingsView: View {
     }
 }
 
-// MARK: - Window level helper
+// MARK: - Window level + size enforcer
 
 private struct FloatingWindowElevator: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let view = NSView()
-        DispatchQueue.main.async { view.window?.level = .floating }
+        DispatchQueue.main.async { Self.configure(view.window) }
         return view
     }
-    func updateNSView(_ nsView: NSView, context: Context) {}
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async { Self.configure(nsView.window) }
+    }
+
+    private static func configure(_ window: NSWindow?) {
+        guard let window else { return }
+        window.level = .floating
+        // Override any macOS-restored frame — saved sizes from older builds
+        // would otherwise produce a window that's too small to scroll into.
+        let size = NSSize(width: 500, height: 700)
+        window.minSize = size
+        window.maxSize = size
+        if window.frame.size != size {
+            window.setContentSize(size)
+        }
+    }
 }
 
 // MARK: - Notification Status

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -173,7 +173,7 @@ struct SettingsView: View {
         }
         .id(formID)
         .formStyle(.grouped)
-        .frame(width: 500, height: 600)
+        .frame(width: 500, height: 700)
         .navigationTitle("Settings")
         .task { await checkNotifPermission() }
         // macOS keeps the Settings window alive between opens (just hides it),

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -173,7 +173,7 @@ struct SettingsView: View {
         }
         .id(formID)
         .formStyle(.grouped)
-        .frame(width: 500)
+        .frame(width: 500, height: 600)
         .navigationTitle("Settings")
         .task { await checkNotifPermission() }
         // macOS keeps the Settings window alive between opens (just hides it),

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A native macOS menu bar app for monitoring AI coding quota. Track [OpenAI Codex]
 - **Guided onboarding** — first launch walks through connecting services, notifications, and widget setup; if both services are connected, onboarding also asks which one should drive the menu bar icon
 - **Single-service adaptation** — when only one service is enrolled, the app and widgets avoid dead space instead of pretending there should be a second column
 - **ChatGPT and Claude sign-in** — authenticates using your existing browser-backed session, with secrets stored in Keychain and shared widget data kept in the app group
-- **Notification controls** — per-service master switches plus threshold alerts for low quota, critical quota, limit reached, and reset events
+- **Notification controls** — per-service master switches plus consolidated threshold alerts (one toggle covers low quota, critical quota, and limit reached) plus reset events
 - **Recovery after updates** — widget timelines reload more aggressively on launch, and installed widgets recover more reliably after app replacements
 - **Auto-update** — Sparkle checks silently on launch and twice daily, with gentle reminders instead of intrusive prompts
 
@@ -109,7 +109,7 @@ See the pre-release checklist at the top of [`scripts/release.sh`](scripts/relea
 ## Roadmap
 
 - [x] Visualize 7-day quota reset timing — the app now surfaces 7-day reset timing when the weekly window enters the warning range
-- [ ] Settings is cramped — too much scrolling, notifications lack hierarchy; needs a structural pass
+- [x] Settings restructured — Accounts section promoted to the top; notification sections named per service with threshold alerts consolidated into a single toggle per window
 - [x] Auth and widget recovery after updates — widgets recover more reliably after app replacements, refresh more aggressively, and valid Claude/Codex sessions now restore automatically instead of showing stale Connect states
 - [x] Widget variations — configurable single-service medium widget plus a large two-service overview
 - [ ] iOS / iPadOS app — native app and home screen widgets for iPhone and iPad

--- a/project.yml
+++ b/project.yml
@@ -14,7 +14,7 @@ options:
 # CURRENT_PROJECT_VERSION = bundle build number used by the app + widget.
 settings:
   base:
-    MARKETING_VERSION: "1.9.9"
+    MARKETING_VERSION: "1.9.10"
     CURRENT_PROJECT_VERSION: "301"
 
 packages:


### PR DESCRIPTION
## Summary
- Bumps `MARKETING_VERSION` to `1.9.10`
- Checks off the Settings structural pass roadmap item
- Updates notification controls feature bullet to reflect consolidated toggles