### PR TITLE
fix: round visual-frame corners in Safari/Orion

### DIFF
--- a/docs/site.css
+++ b/docs/site.css
@@ -322,6 +322,7 @@ video {
   position: relative;
   overflow: hidden;
   border-radius: 34px;
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
   border: 1px solid rgba(255, 255, 255, 0.07);
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015)),


### PR DESCRIPTION
## Summary

- Adds `-webkit-mask-image: -webkit-radial-gradient(white, black)` to `.visual-frame` so `overflow: hidden` correctly clips the `border-radius` in WebKit-based browsers (Safari, Orion)
- The previous fix only applied the mask to the inner `.hero-demo-media` child, leaving the outer frame's top-left corner unclipped

## Test plan

- [ ] Load the site in Safari or Orion and confirm all four corners of the demo frame are rounded