### PR TITLE
fix: apply clip-path to video element for Safari/Orion corner rounding

### DIFF
--- a/docs/site.css
+++ b/docs/site.css
@@ -367,6 +367,7 @@ video {
   border-radius: inherit;
   background: #000;
   -webkit-mask-image: -webkit-radial-gradient(white, black);
+  clip-path: inset(0 round 34px);
 }
 
 .hero-demo-video {

--- a/docs/site.css
+++ b/docs/site.css
@@ -380,6 +380,7 @@ video {
   background: #000;
   cursor: pointer;
   transition: filter 0.24s ease;
+  clip-path: inset(0 round 34px);
 }
 
 .hero-demo-video.is-paused {

--- a/docs/site.css
+++ b/docs/site.css
@@ -322,6 +322,7 @@ video {
   position: relative;
   overflow: hidden;
   border-radius: 34px;
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
   border: 1px solid rgba(255, 255, 255, 0.07);
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015)),


### PR DESCRIPTION
## Summary

- WebKit (Safari, Orion) renders `<video>` on a native compositor layer that ignores `clip-path` and `overflow: hidden` on parent elements
- Applies `clip-path: inset(0 round 34px)` directly to `.hero-demo-video` so the clip is enforced at the compositor level
- Chrome was already working; this targets the Safari/Orion regression