### PR TITLE
fix: smoke check before minification

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -19,14 +19,14 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Smoke check site
+        run: ./scripts/check-site-pages.sh
+
       - name: Minify site assets
         run: |
           npm install -g lightningcss-cli terser
           lightningcss --minify docs/site.css -o docs/site.css
           terser docs/site.js -o docs/site.js --compress --mangle
-
-      - name: Smoke check site
-        run: ./scripts/check-site-pages.sh
 
       - name: Set up SSH
         run: |

--- a/docs/site.css
+++ b/docs/site.css
@@ -367,6 +367,7 @@ video {
   border-radius: inherit;
   background: #000;
   -webkit-mask-image: -webkit-radial-gradient(white, black);
+  clip-path: inset(0 round 34px);
 }
 
 .hero-demo-video {

--- a/docs/site.css
+++ b/docs/site.css
@@ -380,6 +380,7 @@ video {
   background: #000;
   cursor: pointer;
   transition: filter 0.24s ease;
+  clip-path: inset(0 round 34px);
 }
 
 .hero-demo-video.is-paused {

--- a/docs/site.css
+++ b/docs/site.css
@@ -322,6 +322,7 @@ video {
   position: relative;
   overflow: hidden;
   border-radius: 34px;
+  -webkit-mask-image: -webkit-radial-gradient(white, black);
   border: 1px solid rgba(255, 255, 255, 0.07);
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.015)),


### PR DESCRIPTION
## Summary

- The deploy was failing because `lightningcss` strips spaces from CSS property values (e.g. `border-radius: inherit;` → `border-radius:inherit`), so the smoke check strings were never found in the minified output
- Moves the smoke check step to run against unminified source, before the minify step

This has been breaking every deploy since at least `9d31232`.