### PR TITLE
feat: GA4 analytics integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ output/playwright/
 
 # Xcode scheme management (machine-specific)
 **/xcschememanagement.plist
+
+# Analytics credentials (never commit — contains GA4 API secret)
+AIQuota/Resources/Analytics.plist

--- a/AIQuota.xcodeproj/project.pbxproj
+++ b/AIQuota.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		72ED593D13B133B274DE2113 /* WelcomeStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872D4B7AB7221C3A55960CE1 /* WelcomeStepView.swift */; };
 		7301F858542C589FF8A78E37 /* UpdaterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3CDEE9A5B7D5B416193D23 /* UpdaterViewModel.swift */; };
 		779B5BCC2EBC1AC187C561A5 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 716B00F14F1370CDAC33B5EB /* SettingsView.swift */; };
+		7FC7023A34574E128139E41C /* Analytics.plist in Resources */ = {isa = PBXBuildFile; fileRef = 095F7EB6636590F35E245E34 /* Analytics.plist */; };
 		924F0EB6579EBF80E4C0FF46 /* WidgetIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1F18DB5A7FD4515D863D71 /* WidgetIntent.swift */; };
 		92585202E96046BAB9CFF37E /* QuotaTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD5E0D36B8FCEF6F2E97EFA /* QuotaTimelineProvider.swift */; };
 		94EB3B6AC94DDB40E367306C /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDE2263EBEB7008EF6988081 /* WebKit.framework */; };
@@ -34,6 +35,7 @@
 		B5FDF2BA2E1AF047B995BACE /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = FB0002B3439366F7C9621561 /* Sparkle */; };
 		B9AB1446FA6064350C523453 /* WidgetGaugeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 384CCB3989C01F13B3E22D43 /* WidgetGaugeView.swift */; };
 		BD011637B9A98BF66EB809CD /* CircularGaugeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B0B4CEC9ACF96AC981FA29 /* CircularGaugeView.swift */; };
+		C85373188A0821406ACB6164 /* AnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CC4153FE01FA354752C247C /* AnalyticsClient.swift */; };
 		E35629D70F3650759EDF8865 /* ServicesStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66610C3B005AD239F7EDE75 /* ServicesStepView.swift */; };
 		F15449DA517BF7C4B79320DC /* PopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B4A02F2F3618A00A9FE938 /* PopoverView.swift */; };
 		F2F0EB0760448D88611066A4 /* WidgetSmallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA7E1FF303A5852FC6BCC6 /* WidgetSmallView.swift */; };
@@ -68,6 +70,8 @@
 /* Begin PBXFileReference section */
 		05DE0EF729DDBD14B958D28B /* AIQuota.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AIQuota.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		07B0B4CEC9ACF96AC981FA29 /* CircularGaugeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularGaugeView.swift; sourceTree = "<group>"; };
+		095F7EB6636590F35E245E34 /* Analytics.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Analytics.plist; sourceTree = "<group>"; };
+		0CC4153FE01FA354752C247C /* AnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClient.swift; sourceTree = "<group>"; };
 		16BD0A4CB52E425D9A5A6C34 /* AIQuotaKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = AIQuotaKit; path = Packages/AIQuotaKit; sourceTree = SOURCE_ROOT; };
 		1F1F18DB5A7FD4515D863D71 /* WidgetIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetIntent.swift; sourceTree = "<group>"; };
 		384CCB3989C01F13B3E22D43 /* WidgetGaugeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetGaugeView.swift; sourceTree = "<group>"; };
@@ -126,6 +130,7 @@
 		0CF29E076C587EA866F75396 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				095F7EB6636590F35E245E34 /* Analytics.plist */,
 				FB0180B641391BD6AFC75C41 /* Assets.xcassets */,
 				E012B199A00FF2ABD9B06DA4 /* Info.plist */,
 			);
@@ -169,6 +174,7 @@
 				A8C3442C7767F3787BD134A1 /* Views */,
 				47A5B1739A08D397C631BFFE /* ViewModels */,
 				0CF29E076C587EA866F75396 /* Resources */,
+				E22515FC13C00843F1A18BA6 /* Analytics */,
 				FA64CFDF72582D2700992C65 /* Demo */,
 				C4AF85B00431CA922F35A916 /* Support */,
 			);
@@ -246,6 +252,14 @@
 				EDE2263EBEB7008EF6988081 /* WebKit.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E22515FC13C00843F1A18BA6 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				0CC4153FE01FA354752C247C /* AnalyticsClient.swift */,
+			);
+			path = Analytics;
 			sourceTree = "<group>";
 		};
 		E6EEDCE741693B8BB8F8AE5A /* Provider */ = {
@@ -378,6 +392,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7FC7023A34574E128139E41C /* Analytics.plist in Resources */,
 				96ECF77AF4F522CAF9619D23 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -453,6 +468,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				72AE89A41BD0B809A9D6DAB9 /* AIQuotaApp.swift in Sources */,
+				C85373188A0821406ACB6164 /* AnalyticsClient.swift in Sources */,
 				1575BAA1F4C10951443BA5C8 /* AnalyticsConsentStepView.swift in Sources */,
 				BD011637B9A98BF66EB809CD /* CircularGaugeView.swift in Sources */,
 				98F43072074B245C01E279A4 /* CountdownView.swift in Sources */,
@@ -518,7 +534,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 301;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -531,7 +547,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 15.0;
-				MARKETING_VERSION = 1.9.8;
+				MARKETING_VERSION = 1.9.11;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/AIQuota/AIQuotaApp.swift
+++ b/AIQuota/AIQuotaApp.swift
@@ -38,6 +38,16 @@ struct AIQuotaApp: App {
         DispatchQueue.main.async {
             WidgetCenter.shared.reloadAllTimelines()
         }
+        // ── Analytics ──────────────────────────────────────────────────────────
+        let analyticsEnabled = _viewModel.wrappedValue.settings.analyticsEnabled
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        Task {
+            await AnalyticsClient.shared.send(
+                "app_launched",
+                params: ["app_version": appVersion],
+                enabled: analyticsEnabled
+            )
+        }
     }
 
     var body: some Scene {

--- a/AIQuota/Analytics/AnalyticsClient.swift
+++ b/AIQuota/Analytics/AnalyticsClient.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Fire-and-forget GA4 Measurement Protocol client.
+/// All sends are silent no-ops when `enabled` is false or `Analytics.plist` is absent.
+actor AnalyticsClient {
+    static let shared = AnalyticsClient()
+
+    private let firebaseAppID: String?
+    private let apiSecret: String?
+    private let instanceID: String
+
+    private init() {
+        if let url = Bundle.main.url(forResource: "Analytics", withExtension: "plist"),
+           let plist = NSDictionary(contentsOf: url) {
+            firebaseAppID = plist["FirebaseAppID"] as? String
+            apiSecret = plist["APISecret"] as? String
+        } else {
+            firebaseAppID = nil
+            apiSecret = nil
+        }
+
+        let key = "analytics.instanceId"
+        if let existing = UserDefaults.standard.string(forKey: key) {
+            instanceID = existing
+        } else {
+            let new = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+            UserDefaults.standard.set(new, forKey: key)
+            instanceID = new
+        }
+    }
+
+    func send(_ eventName: String, params: [String: String] = [:], enabled: Bool) async {
+        guard enabled,
+              let appID = firebaseAppID,
+              let secret = apiSecret else { return }
+
+        var components = URLComponents(string: "https://www.google-analytics.com/mp/collect")!
+        components.queryItems = [
+            URLQueryItem(name: "firebase_app_id", value: appID),
+            URLQueryItem(name: "api_secret", value: secret)
+        ]
+        guard let url = components.url else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "app_instance_id": instanceID,
+            "events": [["name": eventName, "params": params]]
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: body) else { return }
+        request.httpBody = data
+
+        _ = try? await URLSession.shared.data(for: request)
+    }
+}

--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -76,6 +76,9 @@ final class QuotaViewModel {
     func completeOnboarding() {
         UserDefaults.standard.set(true, forKey: "onboarding.v1.hasCompleted")
         onboardingTriggeredThisSession = true
+        Task {
+            await AnalyticsClient.shared.send("onboarding_completed", enabled: settings.analyticsEnabled)
+        }
     }
 
     func resetOnboardingForReplay() {
@@ -200,6 +203,13 @@ final class QuotaViewModel {
                     if state == .authenticated && !self.enrolledServices.contains(.codex) {
                         self.enrolledServices.insert(.codex)
                         SharedDefaults.enrollService(.codex)
+                        Task {
+                            await AnalyticsClient.shared.send(
+                                "service_connected",
+                                params: ["service_name": "codex"],
+                                enabled: self.settings.analyticsEnabled
+                            )
+                        }
                     }
                     if state == .authenticated && self.refreshTask == nil {
                         self.startAutoRefresh()
@@ -470,6 +480,13 @@ final class QuotaViewModel {
             if !enrolledServices.contains(.claude) {
                 enrolledServices.insert(.claude)
                 SharedDefaults.enrollService(.claude)
+                Task {
+                    await AnalyticsClient.shared.send(
+                        "service_connected",
+                        params: ["service_name": "claude"],
+                        enabled: settings.analyticsEnabled
+                    )
+                }
             }
             await refreshClaude()
             if refreshTask == nil { startAutoRefresh() }

--- a/docs/superpowers/plans/2026-04-09-analytics-integration.md
+++ b/docs/superpowers/plans/2026-04-09-analytics-integration.md
@@ -1,0 +1,318 @@
+# Analytics Integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire up GA4 Measurement Protocol event sending in the macOS app, gated on the existing `analyticsEnabled` preference.
+
+**Architecture:** A new `AnalyticsClient` actor in the main app target reads credentials from a gitignored `Analytics.plist` bundle resource and sends events via `URLSession`. All sends are no-ops when `analyticsEnabled` is false or the plist is absent. Three call sites: app launch, onboarding completion, and first service sign-in.
+
+**Tech Stack:** Swift 6, `URLSession.shared.data(for:)`, GA4 Measurement Protocol (app stream), `UserDefaults.standard` for per-install UUID.
+
+---
+
+### Task 1: Add `Analytics.plist` (gitignored credentials) and update `.gitignore`
+
+**Files:**
+- Create: `AIQuota/Resources/Analytics.plist`
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Create `AIQuota/Resources/Analytics.plist`** with the real credentials:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>FirebaseAppID</key>
+    <string>1:106661566945:ios:866e3fabb60b02c0cc9aa0</string>
+    <key>APISecret</key>
+    <string>gNE5XhiSSI-E2HhlSlQYng</string>
+</dict>
+</plist>
+```
+
+- [ ] **Step 2: Add `Analytics.plist` to `.gitignore`** so credentials never enter the repo. Append to `.gitignore`:
+
+```
+# Analytics credentials (never commit — contains GA4 API secret)
+AIQuota/Resources/Analytics.plist
+```
+
+- [ ] **Step 3: Commit only the `.gitignore` change** (do not stage `Analytics.plist`):
+
+```bash
+git add .gitignore
+git commit -m "chore: gitignore Analytics.plist credentials"
+```
+
+Expected: `.gitignore` committed; `Analytics.plist` remains untracked and unindexed.
+
+---
+
+### Task 2: Create `AnalyticsClient`
+
+**Files:**
+- Create: `AIQuota/Analytics/AnalyticsClient.swift`
+
+No unit tests: this is a thin HTTP wrapper whose observable output is a network call. Correctness is validated in Task 4 via the GA4 Realtime report.
+
+- [ ] **Step 1: Create `AIQuota/Analytics/AnalyticsClient.swift`**:
+
+```swift
+import Foundation
+
+/// Fire-and-forget GA4 Measurement Protocol client.
+/// All sends are silent no-ops when `enabled` is false or `Analytics.plist` is absent.
+actor AnalyticsClient {
+    static let shared = AnalyticsClient()
+
+    private let firebaseAppID: String?
+    private let apiSecret: String?
+    private let instanceID: String
+
+    private init() {
+        if let url = Bundle.main.url(forResource: "Analytics", withExtension: "plist"),
+           let plist = NSDictionary(contentsOf: url) {
+            firebaseAppID = plist["FirebaseAppID"] as? String
+            apiSecret = plist["APISecret"] as? String
+        } else {
+            firebaseAppID = nil
+            apiSecret = nil
+        }
+
+        let key = "analytics.instanceId"
+        if let existing = UserDefaults.standard.string(forKey: key) {
+            instanceID = existing
+        } else {
+            let new = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased()
+            UserDefaults.standard.set(new, forKey: key)
+            instanceID = new
+        }
+    }
+
+    func send(_ eventName: String, params: [String: String] = [:], enabled: Bool) async {
+        guard enabled,
+              let appID = firebaseAppID,
+              let secret = apiSecret else { return }
+
+        var components = URLComponents(string: "https://www.google-analytics.com/mp/collect")!
+        components.queryItems = [
+            URLQueryItem(name: "firebase_app_id", value: appID),
+            URLQueryItem(name: "api_secret", value: secret)
+        ]
+        guard let url = components.url else { return }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let body: [String: Any] = [
+            "app_instance_id": instanceID,
+            "events": [["name": eventName, "params": params]]
+        ]
+        guard let data = try? JSONSerialization.data(withJSONObject: body) else { return }
+        request.httpBody = data
+
+        _ = try? await URLSession.shared.data(for: request)
+    }
+}
+```
+
+- [ ] **Step 2: Regenerate the Xcode project** so XcodeGen picks up the new file:
+
+```bash
+xcodegen generate
+```
+
+Expected: no errors; `AnalyticsClient.swift` appears in the `AIQuota` group in Xcode.
+
+- [ ] **Step 3: Build to confirm the new file compiles**:
+
+```bash
+xcodebuild -scheme AIQuota -destination 'platform=macOS' build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 4: Commit**:
+
+```bash
+git add AIQuota/Analytics/AnalyticsClient.swift project.yml
+git commit -m "feat: add AnalyticsClient (GA4 Measurement Protocol)"
+```
+
+---
+
+### Task 3: Wire the three call sites
+
+**Files:**
+- Modify: `AIQuota/AIQuotaApp.swift`
+- Modify: `AIQuota/ViewModels/QuotaViewModel.swift`
+
+- [ ] **Step 1: Fire `app_launched` in `AIQuotaApp.init()`.**
+
+In `AIQuotaApp.init()`, after `_viewModel = State(initialValue: QuotaViewModel())`, add:
+
+```swift
+let analyticsEnabled = _viewModel.wrappedValue.settings.analyticsEnabled
+let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+Task {
+    await AnalyticsClient.shared.send(
+        "app_launched",
+        params: ["app_version": appVersion],
+        enabled: analyticsEnabled
+    )
+}
+```
+
+Full updated `init()` for reference (additions marked):
+
+```swift
+init() {
+    LegacyWebKitMigration.migrateIfNeeded(bundleIdentifier: "com.niederme.AIQuota")
+    LegacyDefaultsMigration.migrateIfNeeded(bundleIdentifier: "com.niederme.AIQuota")
+    LaunchServicesSync.repairIfNeeded()
+    _viewModel = State(initialValue: QuotaViewModel())
+    #if DEMO_MODE
+    _demoDriver = State(initialValue: DemoDriver())
+    #endif
+    updaterController = SPUStandardUpdaterController(
+        startingUpdater: true,
+        updaterDelegate: nil,
+        userDriverDelegate: gentleDriverDelegate
+    )
+    let updater = updaterController.updater
+    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        updater.checkForUpdatesInBackground()
+    }
+    DispatchQueue.main.async {
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+    // ── Analytics ──────────────────────────────────────────────────────────
+    let analyticsEnabled = _viewModel.wrappedValue.settings.analyticsEnabled
+    let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+    Task {
+        await AnalyticsClient.shared.send(
+            "app_launched",
+            params: ["app_version": appVersion],
+            enabled: analyticsEnabled
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Fire `onboarding_completed` in `QuotaViewModel.completeOnboarding()`.**
+
+Current (line 76–79):
+```swift
+func completeOnboarding() {
+    UserDefaults.standard.set(true, forKey: "onboarding.v1.hasCompleted")
+    onboardingTriggeredThisSession = true
+}
+```
+
+Replace with:
+```swift
+func completeOnboarding() {
+    UserDefaults.standard.set(true, forKey: "onboarding.v1.hasCompleted")
+    onboardingTriggeredThisSession = true
+    Task {
+        await AnalyticsClient.shared.send("onboarding_completed", enabled: settings.analyticsEnabled)
+    }
+}
+```
+
+- [ ] **Step 3: Fire `service_connected` on first Claude sign-in.**
+
+In `signInClaude()` (around line 470), the block that guards `!enrolledServices.contains(.claude)`:
+
+Current:
+```swift
+if !enrolledServices.contains(.claude) {
+    enrolledServices.insert(.claude)
+    SharedDefaults.enrollService(.claude)
+}
+```
+
+Replace with:
+```swift
+if !enrolledServices.contains(.claude) {
+    enrolledServices.insert(.claude)
+    SharedDefaults.enrollService(.claude)
+    Task {
+        await AnalyticsClient.shared.send(
+            "service_connected",
+            params: ["service_name": "claude"],
+            enabled: settings.analyticsEnabled
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Fire `service_connected` on first Codex sign-in.**
+
+In `QuotaViewModel.init()`, the stateStream observer for Codex (around line 200):
+
+Current:
+```swift
+if state == .authenticated && !self.enrolledServices.contains(.codex) {
+    self.enrolledServices.insert(.codex)
+    SharedDefaults.enrollService(.codex)
+}
+```
+
+Replace with:
+```swift
+if state == .authenticated && !self.enrolledServices.contains(.codex) {
+    self.enrolledServices.insert(.codex)
+    SharedDefaults.enrollService(.codex)
+    Task {
+        await AnalyticsClient.shared.send(
+            "service_connected",
+            params: ["service_name": "codex"],
+            enabled: self.settings.analyticsEnabled
+        )
+    }
+}
+```
+
+- [ ] **Step 5: Build to confirm everything compiles**:
+
+```bash
+xcodebuild -scheme AIQuota -destination 'platform=macOS' build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`
+
+- [ ] **Step 6: Commit**:
+
+```bash
+git add AIQuota/AIQuotaApp.swift AIQuota/ViewModels/QuotaViewModel.swift
+git commit -m "feat: fire analytics events on launch, onboarding, and service sign-in"
+```
+
+---
+
+### Task 4: Validate in GA4 Realtime
+
+- [ ] **Step 1: Open the app in debug mode.** In Xcode, run the `AIQuota` scheme. The app must have `analyticsEnabled = true` — enable it in Settings → Privacy or go through onboarding and opt in.
+
+- [ ] **Step 2: Open GA4 Realtime report.** Go to analytics.google.com → the `aiquota` property → Reports → Realtime. Events should appear within 30 seconds.
+
+- [ ] **Step 3: Verify `app_launched` fires on each launch.** Relaunch the app from Xcode. Confirm `app_launched` with `app_version` property appears in Realtime.
+
+- [ ] **Step 4: Verify `onboarding_completed` fires.** Reset onboarding from Settings → "Guided Setup…", complete the wizard. Confirm `onboarding_completed` appears in Realtime.
+
+- [ ] **Step 5: Verify `service_connected` fires.** Sign out a service and sign back in. Confirm `service_connected` with `service_name` property appears in Realtime.
+
+- [ ] **Step 6: Verify no events fire when disabled.** Set `analyticsEnabled = false` in Settings → Privacy, relaunch. Confirm no new events appear in GA4 Realtime.
+
+---
+
+### Task 5: Open Xcode in worktree
+
+- [ ] **Step 1: Open Xcode from the worktree path** (per project convention):
+
+```bash
+open /Users/niederme/~Repos/ai-quota/.claude/worktrees/inspiring-bardeen/AIQuota.xcodeproj
+```

--- a/docs/superpowers/specs/2026-04-09-analytics-integration-design.md
+++ b/docs/superpowers/specs/2026-04-09-analytics-integration-design.md
@@ -1,0 +1,79 @@
+# Analytics Integration Design
+
+**Date:** 2026-04-09
+**Goal:** Wire up GA4 Measurement Protocol event sending in the macOS app, gated on the existing `analyticsEnabled` preference.
+
+---
+
+## Architecture
+
+A new `AnalyticsClient` actor lives in the main app target (`AIQuota/Analytics/AnalyticsClient.swift`). It is a fire-and-forget HTTP client — no SDK, no external dependencies. All calls are gated on `analyticsEnabled`; if the flag is false or credentials are missing, calls return immediately without network activity.
+
+Credentials (`firebase_app_id` and `api_secret`) are stored in `AIQuota/Resources/Analytics.plist`, which is gitignored. If the file is absent from the bundle (e.g., open-source builds), all analytics calls become silent no-ops.
+
+A per-install UUID (`analytics.instanceId`) is generated on first launch and persisted in `UserDefaults.standard`. This is the `app_instance_id` GA4 requires to correlate events to an install.
+
+---
+
+## Endpoint
+
+GA4 Measurement Protocol for app streams:
+
+```
+POST https://www.google-analytics.com/mp/collect
+  ?firebase_app_id={FIREBASE_APP_ID}
+  &api_secret={API_SECRET}
+```
+
+Body (JSON):
+```json
+{
+  "app_instance_id": "<per-install UUID>",
+  "events": [{ "name": "event_name", "params": { "key": "value" } }]
+}
+```
+
+---
+
+## Events
+
+| Event | Fired from | Properties |
+|---|---|---|
+| `app_launched` | `AIQuotaApp.init()` | `app_version` (marketing version string from Bundle) |
+| `onboarding_completed` | `QuotaViewModel.completeOnboarding()` | — |
+| `service_connected` | `QuotaViewModel.enroll(_:)` | `service_name` ("claude" or "codex") |
+
+These match exactly what the onboarding consent copy promised: installs, active use, app version, and setup completion.
+
+---
+
+## Components
+
+### `Analytics.plist` (gitignored)
+Keys: `FirebaseAppID` (String), `APISecret` (String).
+
+### `AnalyticsClient` (actor)
+- `static let shared` singleton
+- `init()` — reads plist from bundle; sets `isConfigured = false` if missing
+- `func send(_ eventName: String, params: [String: String] = [:], enabled: Bool)` — checks `isConfigured && enabled` before POSTing; errors are silently discarded
+- Uses `URLSession.shared.data(for:)` (async, Task-cancellation-safe)
+
+### Call sites
+- `AIQuotaApp.init()` — `Task { await AnalyticsClient.shared.send("app_launched", ...) }`
+- `QuotaViewModel.completeOnboarding()` — same pattern
+- `QuotaViewModel.enroll(_:)` — same pattern, passes service name
+
+---
+
+## Testing
+
+No unit tests for `AnalyticsClient` itself (it is a thin HTTP wrapper and its output is the network call). The existing `AnalyticsConsentSettingsTests` already cover the `analyticsEnabled` persistence layer. Manual validation via GA4 DebugView (`-FIRAnalyticsDebugEnabled` launch argument is not applicable here; use GA4 Realtime report instead).
+
+---
+
+## Security / Privacy
+
+- `Analytics.plist` is gitignored — credentials never enter the public repo
+- The API secret is readable from the app binary (unavoidable for client-side analytics); this is accepted — the secret can only send events to this GA4 property, not read from it
+- No PII is collected: no user ID, no tokens, no prompt content
+- All sending is gated on the user's explicit opt-in (`analyticsEnabled = false` by default)


### PR DESCRIPTION
## Summary
- Adds `AnalyticsClient` — a lightweight GA4 Measurement Protocol actor (no SDK, just `URLSession`)
- Credentials stored in gitignored `Analytics.plist`; missing file = silent no-op (safe for open-source builds)
- Fires three events gated on the existing `analyticsEnabled` opt-in: `app_launched` (with `app_version`), `onboarding_completed`, and `service_connected` (with `service_name`)

## Test Plan
- [ ] Enable analytics in Settings → Privacy
- [ ] Run app and confirm `app_launched` appears in GA4 Realtime within ~30 seconds
- [ ] Reset onboarding (Settings → Guided Setup), complete wizard, confirm `onboarding_completed`
- [ ] Sign out a service and sign back in, confirm `service_connected`
- [ ] Disable analytics, relaunch — confirm no new events appear in GA4 Realtime