### PR TITLE
Increase footer row gap from 10px to 14px

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -174,7 +174,7 @@
               <details class="faq-item">
                 <summary>Need help?</summary>
                 <p>
-                  Email <a href="mailto:help@aiquota.app">help@aiquota.app</a> if you run into a
+                  Email <a href="mailto:help@aiquota.app?subject=AIQuota%20Issue%20Report&body=Describe%20the%20issue%20you%20encountered%3A%0A%0A">help@aiquota.app</a> if you run into a
                   problem, have a question, or want to report a bug.
                 </p>
               </details>
@@ -188,6 +188,8 @@
           <div class="footer-meta">
             <p>
               <a href="https://nieder.me/">&copy; John Niedermeyer</a>
+              <span class="footer-sep">&nbsp;&nbsp;&nbsp;&nbsp;</span>
+              Need Help? <a href="mailto:help@aiquota.app?subject=AIQuota%20Issue%20Report&body=Describe%20the%20issue%20you%20encountered%3A%0A%0A">Email help@aiquota.app</a>
             </p>
           </div>
           <div class="footer-links">

--- a/docs/site.css
+++ b/docs/site.css
@@ -706,7 +706,7 @@ video {
 .site-footer .container {
   flex-direction: column;
   justify-content: center;
-  gap: 10px;
+  gap: 14px;
 }
 
 .footer-meta {


### PR DESCRIPTION
## Summary
- Opens up spacing between the copyright/help row and the links row in the site footer from 10px to 14px