### PR TITLE
[codex] Refine docs light mode and site tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,9 +40,15 @@ The full release script is at `scripts/release.sh`. It handles zipping, signing,
    ```
    The script will open a text editor to edit release notes, then zip, sign, update appcast, create GitHub release, and push.
 
-5. **Commit & push** the updated `appcast.xml`:
+5. **Verify the website release page is in sync with GitHub**:
    ```bash
-   git add appcast.xml && git commit -m "chore: update appcast for vX.Y.NEW" && git push
+   ./scripts/check-site-pages.sh
+   ```
+   If the release page drifted, update `docs/releases/index.html` before pushing.
+
+6. **Commit & push** the updated `appcast.xml` and any site changes:
+   ```bash
+   git add appcast.xml docs/releases/index.html && git commit -m "chore: update release metadata for vX.Y.NEW" && git push
    ```
 
 > **Important:** `appcast.xml` must also be uploaded as a release asset on the GitHub release — Sparkle fetches it from `releases/latest/download/appcast.xml`. The `release.sh` script does this automatically. If doing a manual release, run:

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Requirements for live reload:
 Pushing to `main` triggers the website deploy workflow automatically, and you can also run the same deploy manually with `workflow_dispatch` in GitHub Actions. The workflow:
 
 - minifies `docs/site.css` and `docs/site.js`
-- smoke-checks the public site pages before deploy
+- smoke-checks the public site pages before deploy, including release-page sync against GitHub
 - stages the `docs/` site with cache-busted asset URLs
 - syncs the staged site to the remote host over SSH
 - normalizes remote file permissions so shared hosting serves the site correctly
@@ -201,6 +201,7 @@ See the pre-release checklist at the top of [`scripts/release.sh`](scripts/relea
 3. Run `./scripts/bump-build.sh` to increment `CURRENT_PROJECT_VERSION` and regenerate the Xcode project
 4. Archive in Xcode (`Product → Archive`) and export the notarized `.app` to `~/Desktop/AIQuota.app`
 5. Run `./scripts/release.sh <version>`
+6. Verify `docs/releases/index.html` matches the GitHub releases list, run `./scripts/check-site-pages.sh`, then push the site/appcast updates to `main`
 
 ---
 

--- a/docs/accessibility/index.html
+++ b/docs/accessibility/index.html
@@ -8,8 +8,23 @@
       name="description"
       content="Accessibility statement for AIQuota, the macOS app for tracking Codex and Claude Code quota."
     />
+    <meta name="color-scheme" content="dark light" />
     <meta name="theme-color" content="#0b1730" />
+    <script>
+      (() => {
+        const storedTheme = window.localStorage.getItem("aiquota-docs-theme");
+        const resolvedTheme =
+          storedTheme === "light" || storedTheme === "dark"
+            ? storedTheme
+            : window.matchMedia("(prefers-color-scheme: light)").matches
+              ? "light"
+              : "dark";
+        document.documentElement.dataset.theme = resolvedTheme;
+        document.documentElement.style.colorScheme = resolvedTheme;
+      })();
+    </script>
     <link rel="stylesheet" href="../site.css" />
+    <script src="../site.js" defer></script>
   </head>
   <body>
     <div class="page-shell">
@@ -30,6 +45,7 @@
             <a href="../">Home</a>
             <a href="../releases/">Releases</a>
             <a href="https://github.com/niederme/ai-quota">GitHub</a>
+            <button class="button theme-toggle" type="button" data-theme-toggle></button>
           </nav>
         </div>
       </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,8 +8,23 @@
       name="description"
       content="AIQuota is a native macOS menu bar app for monitoring Codex and Claude Code quota with widgets, reset timers, and alerts."
     />
+    <meta name="color-scheme" content="dark light" />
     <meta name="theme-color" content="#0b1730" />
+    <script>
+      (() => {
+        const storedTheme = window.localStorage.getItem("aiquota-docs-theme");
+        const resolvedTheme =
+          storedTheme === "light" || storedTheme === "dark"
+            ? storedTheme
+            : window.matchMedia("(prefers-color-scheme: light)").matches
+              ? "light"
+              : "dark";
+        document.documentElement.dataset.theme = resolvedTheme;
+        document.documentElement.style.colorScheme = resolvedTheme;
+      })();
+    </script>
     <link rel="stylesheet" href="site.css" />
+    <script src="site.js" defer></script>
   </head>
   <body>
     <div class="page-shell">
@@ -30,6 +45,7 @@
             <a href="./">Home</a>
             <a href="./releases/">Releases</a>
             <a href="https://github.com/niederme/ai-quota">GitHub</a>
+            <button class="button theme-toggle" type="button" data-theme-toggle></button>
             <a
               class="button"
               href="https://github.com/niederme/ai-quota/releases/latest/download/AIQuota.zip"
@@ -200,6 +216,5 @@
         </div>
       </footer>
     </div>
-    <script src="site.js"></script>
   </body>
 </html>

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -8,8 +8,23 @@
       name="description"
       content="Privacy Policy for AIQuota, the macOS app for tracking Codex and Claude Code quota."
     />
+    <meta name="color-scheme" content="dark light" />
     <meta name="theme-color" content="#0b1730" />
+    <script>
+      (() => {
+        const storedTheme = window.localStorage.getItem("aiquota-docs-theme");
+        const resolvedTheme =
+          storedTheme === "light" || storedTheme === "dark"
+            ? storedTheme
+            : window.matchMedia("(prefers-color-scheme: light)").matches
+              ? "light"
+              : "dark";
+        document.documentElement.dataset.theme = resolvedTheme;
+        document.documentElement.style.colorScheme = resolvedTheme;
+      })();
+    </script>
     <link rel="stylesheet" href="../site.css" />
+    <script src="../site.js" defer></script>
   </head>
   <body>
     <div class="page-shell">
@@ -30,6 +45,7 @@
             <a href="../">Home</a>
             <a href="../releases/">Releases</a>
             <a href="https://github.com/niederme/ai-quota">GitHub</a>
+            <button class="button theme-toggle" type="button" data-theme-toggle></button>
           </nav>
         </div>
       </header>

--- a/docs/releases/index.html
+++ b/docs/releases/index.html
@@ -8,8 +8,23 @@
       name="description"
       content="Release information and download links for AIQuota, the macOS quota tracker for Codex and Claude Code."
     />
+    <meta name="color-scheme" content="dark light" />
     <meta name="theme-color" content="#0b1730" />
+    <script>
+      (() => {
+        const storedTheme = window.localStorage.getItem("aiquota-docs-theme");
+        const resolvedTheme =
+          storedTheme === "light" || storedTheme === "dark"
+            ? storedTheme
+            : window.matchMedia("(prefers-color-scheme: light)").matches
+              ? "light"
+              : "dark";
+        document.documentElement.dataset.theme = resolvedTheme;
+        document.documentElement.style.colorScheme = resolvedTheme;
+      })();
+    </script>
     <link rel="stylesheet" href="../site.css" />
+    <script src="../site.js" defer></script>
   </head>
   <body>
     <div class="page-shell">
@@ -30,6 +45,7 @@
             <a href="../">Home</a>
             <a href="../releases/">Releases</a>
             <a href="https://github.com/niederme/ai-quota">GitHub</a>
+            <button class="button theme-toggle" type="button" data-theme-toggle></button>
             <a
               class="button"
               href="https://github.com/niederme/ai-quota/releases/latest/download/AIQuota.zip"

--- a/docs/site.css
+++ b/docs/site.css
@@ -41,12 +41,29 @@
   --content: 1180px;
 }
 
+html[data-theme="light"] {
+  --bg: #f4f7fc;
+  --bg-soft: #fbfdff;
+  --panel: rgba(255, 255, 255, 0.76);
+  --panel-strong: rgba(255, 255, 255, 0.92);
+  --line: rgba(56, 73, 112, 0.12);
+  --text: #15233f;
+  --muted: #5f6d88;
+  --success: #2e8d5b;
+  --shadow: 0 28px 72px rgba(76, 91, 136, 0.14);
+}
+
 * {
   box-sizing: border-box;
 }
 
 html {
   scroll-behavior: smooth;
+  color-scheme: dark;
+}
+
+html[data-theme="light"] {
+  color-scheme: light;
 }
 
 body {
@@ -62,6 +79,14 @@ body {
     linear-gradient(180deg, #15345d 0%, #101b34 34%, #070d18 100%);
 }
 
+html[data-theme="light"] body {
+  background:
+    radial-gradient(circle at top left, rgba(98, 157, 255, 0.18), transparent 30%),
+    radial-gradient(circle at 85% 10%, rgba(173, 146, 255, 0.2), transparent 24%),
+    radial-gradient(circle at 58% 100%, rgba(148, 194, 255, 0.12), transparent 32%),
+    linear-gradient(180deg, #fbfcff 0%, #f3f6fb 52%, #edf2f8 100%);
+}
+
 body::before {
   content: "";
   position: fixed;
@@ -72,6 +97,14 @@ body::before {
     radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.06), transparent 20%),
     radial-gradient(circle at 30% 70%, rgba(255, 255, 255, 0.05), transparent 22%);
   opacity: 0.8;
+}
+
+html[data-theme="light"] body::before {
+  background:
+    radial-gradient(circle at 22% 18%, rgba(255, 255, 255, 0.7), transparent 18%),
+    radial-gradient(circle at 72% 32%, rgba(255, 255, 255, 0.5), transparent 20%),
+    radial-gradient(circle at 32% 72%, rgba(255, 255, 255, 0.34), transparent 22%);
+  opacity: 1;
 }
 
 a {
@@ -124,6 +157,12 @@ video {
     0 12px 34px rgba(97, 92, 255, 0.24);
 }
 
+html[data-theme="light"] .brand-icon {
+  box-shadow:
+    0 0 0 12px rgba(97, 92, 255, 0.1),
+    0 16px 34px rgba(97, 92, 255, 0.18);
+}
+
 .site-nav {
   display: flex;
   align-items: center;
@@ -138,6 +177,60 @@ video {
 .site-nav a:hover,
 .site-nav a:focus-visible {
   color: var(--text);
+}
+
+.theme-toggle {
+  position: relative;
+  width: 42px;
+  min-width: 42px;
+  min-height: 42px;
+  padding: 0;
+  justify-content: center;
+  border-radius: 999px;
+  box-shadow: none;
+}
+
+.theme-toggle::before {
+  content: "";
+  width: 16px;
+  height: 16px;
+  border-radius: 999px;
+  flex: 0 0 auto;
+}
+
+html[data-theme="dark"] .theme-toggle::before {
+  background: radial-gradient(circle at 32% 32%, #f8fbff 0%, #dce3ff 38%, #97a2ff 72%, #5d69ff 100%);
+  box-shadow:
+    0 0 0 4px rgba(123, 136, 255, 0.16),
+    0 0 22px rgba(109, 122, 255, 0.24);
+}
+
+html[data-theme="light"] .theme-toggle::before {
+  background: radial-gradient(circle at 34% 34%, #fff6be 0%, #ffd773 44%, #ffb55c 76%, #ff9553 100%);
+  box-shadow:
+    0 0 0 4px rgba(255, 199, 91, 0.18),
+    0 0 22px rgba(255, 164, 81, 0.2);
+}
+
+html[data-theme="dark"] .theme-toggle {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+html[data-theme="dark"] .theme-toggle:hover,
+html[data-theme="dark"] .theme-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+html[data-theme="light"] .theme-toggle {
+  background: rgba(255, 255, 255, 0.56);
+  border-color: rgba(61, 79, 122, 0.12);
+}
+
+html[data-theme="light"] .theme-toggle:hover,
+html[data-theme="light"] .theme-toggle:focus-visible {
+  background: rgba(255, 255, 255, 0.82);
+  border-color: rgba(61, 79, 122, 0.18);
 }
 
 .button {
@@ -166,6 +259,19 @@ video {
   border-color: rgba(255, 255, 255, 0.18);
 }
 
+html[data-theme="light"] .button {
+  background: rgba(255, 255, 255, 0.68);
+  color: var(--text);
+  border-color: rgba(61, 79, 122, 0.16);
+  box-shadow: 0 12px 28px rgba(74, 88, 128, 0.08);
+}
+
+html[data-theme="light"] .button:hover,
+html[data-theme="light"] .button:focus-visible {
+  background: rgba(255, 255, 255, 0.92);
+  border-color: rgba(61, 79, 122, 0.24);
+}
+
 .button-primary {
   border: 0;
   background: linear-gradient(135deg, #ab7bff 0%, #8e49ff 48%, #615cff 100%);
@@ -176,6 +282,18 @@ video {
 .button-primary:focus-visible {
   background: linear-gradient(135deg, #b68aff 0%, #9c5dff 48%, #726cff 100%);
   box-shadow: 0 22px 46px rgba(97, 92, 255, 0.36);
+}
+
+html[data-theme="light"] .button-primary {
+  color: #fffdfd;
+  background: linear-gradient(135deg, #3a5dff 0%, #615cff 52%, #8a67ff 100%);
+  box-shadow: 0 20px 42px rgba(88, 101, 255, 0.26);
+}
+
+html[data-theme="light"] .button-primary:hover,
+html[data-theme="light"] .button-primary:focus-visible {
+  background: linear-gradient(135deg, #4769ff 0%, #6c67ff 52%, #9775ff 100%);
+  box-shadow: 0 22px 46px rgba(88, 101, 255, 0.3);
 }
 
 .hero {
@@ -310,6 +428,16 @@ video {
     inset 0 0 0 1px rgba(255, 255, 255, 0.03);
 }
 
+html[data-theme="light"] .visual-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96), rgba(243, 246, 255, 0.94)),
+    rgba(255, 255, 255, 0.88);
+  border-color: rgba(65, 81, 122, 0.11);
+  box-shadow:
+    0 26px 72px rgba(85, 98, 149, 0.16),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.7);
+}
+
 .visual-card::before {
   content: "";
   position: absolute;
@@ -319,6 +447,10 @@ video {
   border-radius: 999px;
   background: radial-gradient(circle, rgba(142, 73, 255, 0.22), transparent 70%);
   filter: blur(12px);
+}
+
+html[data-theme="light"] .visual-card::before {
+  background: radial-gradient(circle, rgba(142, 73, 255, 0.16), transparent 72%);
 }
 
 .visual-frame {
@@ -335,6 +467,16 @@ video {
   box-shadow:
     inset 0 0 0 1px rgba(255, 255, 255, 0.02),
     0 18px 48px rgba(0, 0, 0, 0.28);
+}
+
+html[data-theme="light"] .visual-frame {
+  border-color: rgba(75, 92, 136, 0.12);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(244, 247, 255, 0.84)),
+    rgba(255, 255, 255, 0.88);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.58),
+    0 18px 48px rgba(93, 103, 146, 0.14);
 }
 
 .visual-frame video,
@@ -465,6 +607,12 @@ video {
   box-shadow: var(--shadow);
 }
 
+html[data-theme="light"] .faq-panel {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(245, 248, 255, 0.88)),
+    rgba(255, 255, 255, 0.82);
+}
+
 .faq-panel-header {
   padding: 34px 34px 28px;
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
@@ -473,12 +621,23 @@ video {
     linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01));
 }
 
+html[data-theme="light"] .faq-panel-header {
+  border-bottom-color: rgba(58, 76, 116, 0.1);
+  background:
+    radial-gradient(circle at top right, rgba(96, 92, 255, 0.12), transparent 26%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.56), rgba(255, 255, 255, 0.2));
+}
+
 .faq-panel-header .feature-kicker {
   margin-bottom: 18px;
   color: #e4efff;
   font-size: 0.94rem;
   gap: 10px;
   letter-spacing: 0.11em;
+}
+
+html[data-theme="light"] .faq-panel-header .feature-kicker {
+  color: #52678f;
 }
 
 .faq-panel-header .feature-kicker::before {
@@ -507,6 +666,10 @@ video {
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+html[data-theme="light"] .faq-item {
+  border-bottom-color: rgba(58, 76, 116, 0.1);
+}
+
 .faq-item:last-child {
   border-bottom: 0;
 }
@@ -515,6 +678,12 @@ video {
   background:
     linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01)),
     linear-gradient(135deg, rgba(96, 92, 255, 0.08), rgba(142, 73, 255, 0.08));
+}
+
+html[data-theme="light"] .faq-item[open] {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.46), rgba(255, 255, 255, 0.18)),
+    linear-gradient(135deg, rgba(96, 92, 255, 0.06), rgba(142, 73, 255, 0.05));
 }
 
 .faq-item[open] summary {
@@ -557,10 +726,21 @@ video {
     border-color 160ms ease;
 }
 
+html[data-theme="light"] .faq-item summary::after {
+  color: #556887;
+  background: rgba(255, 255, 255, 0.84);
+  border-color: rgba(76, 94, 135, 0.14);
+}
+
 .faq-item[open] summary::after {
   transform: rotate(45deg);
   background: rgba(255, 255, 255, 0.12);
   border-color: rgba(255, 255, 255, 0.14);
+}
+
+html[data-theme="light"] .faq-item[open] summary::after {
+  background: rgba(255, 255, 255, 0.94);
+  border-color: rgba(76, 94, 135, 0.2);
 }
 
 .faq-item summary:focus-visible {
@@ -634,6 +814,11 @@ video {
   letter-spacing: 0.11em;
 }
 
+html[data-theme="light"] .feature-kicker,
+html[data-theme="light"] .release-kicker {
+  color: #5b7097;
+}
+
 .feature-kicker::before,
 .release-kicker::before {
   content: "";
@@ -659,6 +844,13 @@ video {
   box-shadow: var(--shadow);
 }
 
+html[data-theme="light"] .release-panel,
+html[data-theme="light"] .policy-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.92), rgba(244, 247, 255, 0.88)),
+    rgba(255, 255, 255, 0.84);
+}
+
 .release-panel h2 {
   margin: 6px 0 10px;
   font-size: clamp(1.7rem, 3vw, 2.4rem);
@@ -676,6 +868,11 @@ video {
   margin: 14px 0 0;
   padding-left: 18px;
   color: #dde8fb;
+}
+
+html[data-theme="light"] .release-card ul,
+html[data-theme="light"] .release-panel ul {
+  color: #30405f;
 }
 
 .release-card li,
@@ -814,6 +1011,10 @@ video {
   color: #dce8fc;
 }
 
+html[data-theme="light"] .policy-lede {
+  color: #2b3e62;
+}
+
 @media (max-width: 1080px) {
   .hero-grid,
   .release-panel,
@@ -850,6 +1051,24 @@ video {
 
   .site-nav {
     flex-wrap: wrap;
+    gap: 10px 8px;
+    width: 100%;
+  }
+
+  .site-nav a {
+    font-size: 0.92rem;
+  }
+
+  .site-nav .button {
+    min-height: 42px;
+    padding: 0 16px;
+    font-size: 0.92rem;
+  }
+
+  .theme-toggle {
+    width: 40px;
+    min-width: 40px;
+    min-height: 40px;
   }
 
   .hero {

--- a/docs/site.js
+++ b/docs/site.js
@@ -1,3 +1,65 @@
+const themeStorageKey = "aiquota-docs-theme";
+const themeColorByMode = {
+  dark: "#0b1730",
+  light: "#f4f7fc",
+};
+
+const themeMediaQuery = window.matchMedia("(prefers-color-scheme: light)");
+const themeColorMeta = document.querySelector('meta[name="theme-color"]');
+const themeToggleButtons = Array.from(document.querySelectorAll("[data-theme-toggle]"));
+
+const getStoredTheme = () => {
+  const storedTheme = window.localStorage.getItem(themeStorageKey);
+  return storedTheme === "light" || storedTheme === "dark" ? storedTheme : null;
+};
+
+const getResolvedTheme = () => {
+  const storedTheme = getStoredTheme();
+  if (storedTheme) {
+    return storedTheme;
+  }
+
+  return themeMediaQuery.matches ? "light" : "dark";
+};
+
+const syncThemeToggle = (theme) => {
+  const nextTheme = theme === "light" ? "dark" : "light";
+
+  themeToggleButtons.forEach((button) => {
+    button.setAttribute("aria-label", `Switch to ${nextTheme} mode`);
+    button.setAttribute("title", `Switch to ${nextTheme} mode`);
+  });
+};
+
+const applyTheme = (theme) => {
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+
+  if (themeColorMeta) {
+    themeColorMeta.setAttribute("content", themeColorByMode[theme]);
+  }
+
+  syncThemeToggle(theme);
+};
+
+applyTheme(getResolvedTheme());
+
+themeToggleButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const nextTheme = document.documentElement.dataset.theme === "light" ? "dark" : "light";
+    window.localStorage.setItem(themeStorageKey, nextTheme);
+    applyTheme(nextTheme);
+  });
+});
+
+themeMediaQuery.addEventListener("change", () => {
+  if (getStoredTheme() !== null) {
+    return;
+  }
+
+  applyTheme(getResolvedTheme());
+});
+
 const demoVideos = Array.from(document.querySelectorAll("[data-demo-video]"));
 
 if (demoVideos.length > 0) {

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -8,8 +8,23 @@
       name="description"
       content="Terms of Service for AIQuota, the macOS app for tracking Codex and Claude Code quota."
     />
+    <meta name="color-scheme" content="dark light" />
     <meta name="theme-color" content="#0b1730" />
+    <script>
+      (() => {
+        const storedTheme = window.localStorage.getItem("aiquota-docs-theme");
+        const resolvedTheme =
+          storedTheme === "light" || storedTheme === "dark"
+            ? storedTheme
+            : window.matchMedia("(prefers-color-scheme: light)").matches
+              ? "light"
+              : "dark";
+        document.documentElement.dataset.theme = resolvedTheme;
+        document.documentElement.style.colorScheme = resolvedTheme;
+      })();
+    </script>
     <link rel="stylesheet" href="../site.css" />
+    <script src="../site.js" defer></script>
   </head>
   <body>
     <div class="page-shell">
@@ -30,6 +45,7 @@
             <a href="../">Home</a>
             <a href="../releases/">Releases</a>
             <a href="https://github.com/niederme/ai-quota">GitHub</a>
+            <button class="button theme-toggle" type="button" data-theme-toggle></button>
           </nav>
         </div>
       </header>

--- a/scripts/check-site-pages.sh
+++ b/scripts/check-site-pages.sh
@@ -44,6 +44,66 @@ check_status() {
   curl -fsS "$BASE_URL$path" >/dev/null
 }
 
+check_release_page_matches_github() {
+  python3 - "$BASE_URL/releases/" <<'PY'
+from datetime import datetime
+import json
+import sys
+from urllib.request import Request, urlopen
+
+page_url = sys.argv[1]
+page_html = urlopen(page_url).read().decode("utf-8")
+api_request = Request(
+    "https://api.github.com/repos/niederme/ai-quota/releases?per_page=4",
+    headers={
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "aiquota-site-check",
+    },
+)
+releases = json.load(urlopen(api_request))
+stable_releases = [
+    release
+    for release in releases
+    if not release.get("draft") and not release.get("prerelease")
+]
+
+if len(stable_releases) < 4:
+    raise SystemExit("Expected at least 4 stable GitHub releases to validate site sync")
+
+def release_date(published_at: str) -> str:
+    published = datetime.strptime(published_at, "%Y-%m-%dT%H:%M:%SZ")
+    return f"{published.strftime('%B')} {published.day}, {published.year}"
+
+missing = []
+for index, release in enumerate(stable_releases[:4]):
+    version = release["tag_name"].removeprefix("v")
+    tag_url = f"https://github.com/niederme/ai-quota/releases/tag/{release['tag_name']}"
+    required_tokens = [
+        f"Version {version}",
+        tag_url,
+        release_date(release["published_at"]),
+    ]
+
+    if index == 0:
+        required_tokens.extend(
+            [
+                f"AIQuota {version}",
+                f"Download {version}",
+            ]
+        )
+
+    for token in required_tokens:
+        if token not in page_html:
+            missing.append(token)
+
+if missing:
+    formatted = "\n".join(f"- {token}" for token in missing)
+    raise SystemExit(
+        "Release page is out of sync with GitHub releases. Missing:\n" + formatted
+    )
+PY
+}
+
 check_contains "/" "Know your limits before they break your flow."
 check_contains "/" "AIQuota gives you clear visibility into Codex and Claude Code usage with Menu Bar"
 check_contains "/" "gauges, desktop widgets, reset timers, and warning states."
@@ -54,6 +114,7 @@ check_contains "/releases/" "<h1>Releases</h1>"
 check_contains "/privacy/" "<h1 class=\"policy-title\">Privacy Policy</h1>"
 check_contains "/terms/" "<h1 class=\"policy-title\">Terms of Service</h1>"
 check_contains "/accessibility/" "<h1 class=\"policy-title\">Accessibility</h1>"
+check_release_page_matches_github
 
 check_status "/site.css"
 check_status "/site.js"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,6 +16,11 @@
 #   7. Commit & push all changes to main
 #   Then run this script and paste the release notes into the editor when it opens.
 #
+# Post-release checklist (do these AFTER this script succeeds):
+#   1. Make sure docs/releases/index.html reflects the latest GitHub releases
+#   2. Run ./scripts/check-site-pages.sh to verify the site, including release-page sync
+#   3. Commit & push the appcast/site updates to main so the website deploy workflow publishes them
+#
 # Prerequisites:
 #   - Sparkle tools in PATH or at $SPARKLE_TOOLS (default: /tmp/sparkle-tools/bin)
 #   - App exported from Xcode to ~/Desktop/AIQuota.app


### PR DESCRIPTION
## What changed

This PR adds a light mode to the marketing site in `docs/` and updates the shared site assets so the homepage, releases page, and policy pages all support the same theme behavior.

It also includes related site workflow updates that were already part of the working tree:
- docs preview and release helper updates in `README.md`, `CLAUDE.md`, and `scripts/release.sh`
- a new `scripts/check-site-pages.sh` smoke check for the static site

## Why

The marketing site only supported a dark presentation. This change adds a light treatment while keeping the dark mode intact, persisting the user's theme choice, and making the toggle available across all public docs pages.

## Impact

- visitors can switch between dark and light mode on the marketing site
- the hero CTA and supporting surfaces have a tuned light-mode treatment rather than inheriting washed-out defaults
- site/release workflows now have a dedicated smoke check script to validate the static docs pages

## Validation

- `bash scripts/check-site-pages.sh`
- manual visual verification via `make dev-live` for the `docs/` site in desktop and mobile light-mode previews
