### PR TITLE
fix: improve gauge ring optical sizing

### DIFF
--- a/AIQuota/Views/CircularGaugeView.swift
+++ b/AIQuota/Views/CircularGaugeView.swift
@@ -42,9 +42,11 @@ struct CircularGaugeView: View {
         return worst >= 85 ? 0.65 : 0.45
     }
 
-    // Both rings equal width (8pt). Inner padding = lw so they touch with no gap.
-    private let lw: CGFloat = 8
-    private var innerPad: CGFloat { lw }  // lw/2 + lw/2 = lw
+    // Outer ring is slightly wider than inner (9pt vs 7pt), with a 2pt optical gap.
+    // innerPad = outerLw/2 + 2 + innerLw/2 = 4.5 + 2 + 3.5 = 10
+    private let outerLw: CGFloat = 9
+    private let innerLw: CGFloat = 7
+    private var innerPad: CGFloat { outerLw / 2 + 2 + innerLw / 2 }
 
     var body: some View {
         VStack(spacing: 4) {
@@ -63,27 +65,27 @@ struct CircularGaugeView: View {
             // ── Outer track ───────────────────────────────────────────
             Circle()
                 .trim(from: 0, to: 0.75)
-                .stroke(.fill.quaternary, style: StrokeStyle(lineWidth: lw, lineCap: .butt))
+                .stroke(.fill.quaternary, style: StrokeStyle(lineWidth: outerLw, lineCap: .butt))
                 .rotationEffect(.degrees(135))
 
             // ── Outer fill (primary) ──────────────────────────────────
             Circle()
                 .trim(from: 0, to: 0.75 * primaryFill)
-                .stroke(statusColor, style: StrokeStyle(lineWidth: lw, lineCap: .butt))
+                .stroke(statusColor, style: StrokeStyle(lineWidth: outerLw, lineCap: .butt))
                 .rotationEffect(.degrees(135))
                 .animation(.easeInOut(duration: 0.5), value: primaryFill)
 
-            // ── Inner track (equal width, touching) ───────────────────
+            // ── Inner track (7pt, 2pt gap from outer) ─────────────────
             Circle()
                 .trim(from: 0, to: 0.75)
-                .stroke(.fill.quaternary, style: StrokeStyle(lineWidth: lw, lineCap: .butt))
+                .stroke(.fill.quaternary, style: StrokeStyle(lineWidth: innerLw, lineCap: .butt))
                 .rotationEffect(.degrees(135))
                 .padding(innerPad)
 
             // ── Inner fill (secondary) ────────────────────────────────
             Circle()
                 .trim(from: 0, to: 0.75 * secondaryFill)
-                .stroke(statusColor.opacity(secondaryOpacity), style: StrokeStyle(lineWidth: lw, lineCap: .butt))
+                .stroke(statusColor.opacity(secondaryOpacity), style: StrokeStyle(lineWidth: innerLw, lineCap: .butt))
                 .rotationEffect(.degrees(135))
                 .padding(innerPad)
                 .animation(.easeInOut(duration: 0.5), value: secondaryFill)

--- a/AIQuotaWidget/Views/WidgetGaugeView.swift
+++ b/AIQuotaWidget/Views/WidgetGaugeView.swift
@@ -34,10 +34,11 @@ struct WidgetGaugeView: View {
         max(primaryPercent, secondaryPercent) >= 85 ? 0.65 : 0.45
     }
 
-    // Scaled dimensions
-    private var outerLW: CGFloat { size * 0.08 }
-    private var innerLW: CGFloat { size * 0.08 }  // equal width
-    private var innerPad: CGFloat { outerLW }      // touching rings
+    // Scaled dimensions — outer ring wider, inner narrower, 2pt-equivalent gap between them.
+    // At size=100: outerLW=9, innerLW=7, gap=2 → innerPad=10
+    private var outerLW: CGFloat { size * 0.090 }
+    private var innerLW: CGFloat { size * 0.070 }
+    private var innerPad: CGFloat { outerLW / 2 + size * 0.020 + innerLW / 2 }
     private var iconPt:   CGFloat { size * 0.16 }
     private var primPt:   CGFloat { size * 0.175 }
     private var secPt:    CGFloat { size * 0.125 }


### PR DESCRIPTION
## Summary

- Outer ring widened from 8pt → 9pt; inner ring narrowed from 8pt → 7pt
- Adds a 2pt air gap between rings (`innerPad = outerLw/2 + 2 + innerLw/2 = 10`)
- Previously both rings were equal-width and flush-touching, causing them to blur into one thick band
- Same fix applied proportionally to `WidgetGaugeView` (`size * 0.090 / 0.070 / 0.020`)

## Test plan

- [ ] Build and run — verify the two gauge rings are visually distinct with a clear gap between them
- [ ] Check Codex (amber/orange) and Claude Code (purple) gauges both look correct
- [ ] Verify widget previews also show the separation at various sizes