### PR TITLE
Prepare 1.9.15 point release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ output/playwright/
 
 # Analytics credentials (never commit — contains GA4 API secret)
 AIQuota/Resources/Analytics.plist
+
+# Firebase app config (local-only even though the values are non-secret)
+AIQuota/Resources/GoogleService-Info.plist

--- a/AIQuota.xcodeproj/project.pbxproj
+++ b/AIQuota.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2A2E12F9C8A44C8AA1B5F001 /* FirebaseAnalyticsCore in Frameworks */ = {isa = PBXBuildFile; productRef = 2A2E12F9C8A44C8AA1B5F005 /* FirebaseAnalyticsCore */; };
+		2A2E12F9C8A44C8AA1B5F002 /* AnalyticsAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A2E12F9C8A44C8AA1B5F003 /* AnalyticsAppDelegate.swift */; };
+		2A2E12F9C8A44C8AA1B5F006 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2A2E12F9C8A44C8AA1B5F007 /* GoogleService-Info.plist */; };
 		1575BAA1F4C10951443BA5C8 /* AnalyticsConsentStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89176CF3C6B8574A223A6E55 /* AnalyticsConsentStepView.swift */; };
 		168599BDC65516BFAFB4B2DF /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AFDFAA7F9E0650962EC80DC /* OnboardingView.swift */; };
 		17126B49397A4A50A1B6325F /* MenuBarIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB657B3EE7EFE0906CC89C7E /* MenuBarIconView.swift */; };
@@ -70,6 +73,8 @@
 		05DE0EF729DDBD14B958D28B /* AIQuota.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AIQuota.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		07B0B4CEC9ACF96AC981FA29 /* CircularGaugeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularGaugeView.swift; sourceTree = "<group>"; };
 		0CC4153FE01FA354752C247C /* AnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClient.swift; sourceTree = "<group>"; };
+		2A2E12F9C8A44C8AA1B5F003 /* AnalyticsAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsAppDelegate.swift; sourceTree = "<group>"; };
+		2A2E12F9C8A44C8AA1B5F007 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		16BD0A4CB52E425D9A5A6C34 /* AIQuotaKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = AIQuotaKit; path = Packages/AIQuotaKit; sourceTree = SOURCE_ROOT; };
 		1F1F18DB5A7FD4515D863D71 /* WidgetIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetIntent.swift; sourceTree = "<group>"; };
 		384CCB3989C01F13B3E22D43 /* WidgetGaugeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetGaugeView.swift; sourceTree = "<group>"; };
@@ -116,6 +121,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2A2E12F9C8A44C8AA1B5F001 /* FirebaseAnalyticsCore in Frameworks */,
 				9FD10589109C0FC5A53692FD /* AIQuotaKit in Frameworks */,
 				B5FDF2BA2E1AF047B995BACE /* Sparkle in Frameworks */,
 				94EB3B6AC94DDB40E367306C /* WebKit.framework in Frameworks */,
@@ -129,6 +135,7 @@
 			isa = PBXGroup;
 			children = (
 				FB0180B641391BD6AFC75C41 /* Assets.xcassets */,
+				2A2E12F9C8A44C8AA1B5F007 /* GoogleService-Info.plist */,
 				E012B199A00FF2ABD9B06DA4 /* Info.plist */,
 			);
 			path = Resources;
@@ -219,6 +226,7 @@
 		C4AF85B00431CA922F35A916 /* Support */ = {
 			isa = PBXGroup;
 			children = (
+				2A2E12F9C8A44C8AA1B5F003 /* AnalyticsAppDelegate.swift */,
 				B11BE061D1CEB4B5B6F120AD /* LaunchServicesSync.swift */,
 			);
 			path = Support;
@@ -312,6 +320,7 @@
 			);
 			name = AIQuota;
 			packageProductDependencies = (
+				2A2E12F9C8A44C8AA1B5F005 /* FirebaseAnalyticsCore */,
 				6F3F89B4746C627C8A2D541C /* AIQuotaKit */,
 				FB0002B3439366F7C9621561 /* Sparkle */,
 			);
@@ -368,6 +377,7 @@
 			mainGroup = 8A80EB9F69E97A481D4D779B;
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
+				2A2E12F9C8A44C8AA1B5F004 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				482320011C9DDFBCEE718F58 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				B29429342060C8AE503CD0EE /* XCLocalSwiftPackageReference "Packages/AIQuotaKit" */,
 			);
@@ -388,6 +398,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				96ECF77AF4F522CAF9619D23 /* Assets.xcassets in Resources */,
+				2A2E12F9C8A44C8AA1B5F006 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -420,6 +431,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2A2E12F9C8A44C8AA1B5F002 /* AnalyticsAppDelegate.swift in Sources */,
 				72AE89A41BD0B809A9D6DAB9 /* AIQuotaApp.swift in Sources */,
 				C85373188A0821406ACB6164 /* AnalyticsClient.swift in Sources */,
 				1575BAA1F4C10951443BA5C8 /* AnalyticsConsentStepView.swift in Sources */,
@@ -806,6 +818,14 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		2A2E12F9C8A44C8AA1B5F004 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = exactVersion;
+				version = 12.7.0;
+			};
+		};
 		482320011C9DDFBCEE718F58 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
@@ -817,6 +837,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2A2E12F9C8A44C8AA1B5F005 /* FirebaseAnalyticsCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 2A2E12F9C8A44C8AA1B5F004 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalyticsCore;
+		};
 		4107956DD8A43F21A1968899 /* AIQuotaKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AIQuotaKit;

--- a/AIQuota.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/AIQuota.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,123 @@
 {
-  "originHash" : "bd524a8f21d40b0cd8c7f7fd7b18dd93177da1e23461cd618cad571696c6443e",
+  "originHash" : "079ccdcb51c60ae54c48e32760b3641b5144381d7419693ef2f9061ff72054ca",
   "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "45210bd1ea695779e6de016ab00fea8c0b7eb2ef",
+        "version" : "12.7.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "35b601a60fbbea2de3ea461f604deaaa4d8bbd0c",
+        "version" : "3.2.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "c2d59acf17a8ba7ed80a763593c67c9c7c006ad1",
+        "version" : "12.5.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "0be208810d2e8b90fcd2464d1816723b47819fe7",
+        "version" : "5.2.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
     {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",
@@ -8,6 +125,15 @@
       "state" : {
         "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
         "version" : "2.9.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "a008af1a102ff3dd6cc3764bb69bf63226d0f5f6",
+        "version" : "1.36.1"
       }
     }
   ],

--- a/AIQuota/AIQuotaApp.swift
+++ b/AIQuota/AIQuotaApp.swift
@@ -6,6 +6,7 @@ import AIQuotaKit
 
 @main
 struct AIQuotaApp: App {
+    @NSApplicationDelegateAdaptor(AnalyticsAppDelegate.self) private var analyticsDelegate
     @State private var viewModel: QuotaViewModel
     #if DEMO_MODE
     @State private var demoDriver: DemoDriver
@@ -38,17 +39,6 @@ struct AIQuotaApp: App {
         DispatchQueue.main.async {
             WidgetCenter.shared.reloadAllTimelines()
         }
-        // ── Analytics ──────────────────────────────────────────────────────────
-        let analyticsEnabled = _viewModel.wrappedValue.settings.analyticsEnabled
-        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
-        let services = _viewModel.wrappedValue.analyticsServicesParam
-        Task {
-            await AnalyticsClient.shared.send(
-                "app_launched",
-                params: ["app_version": appVersion, "services": services],
-                enabled: analyticsEnabled
-            )
-        }
     }
 
     var body: some Scene {
@@ -60,11 +50,11 @@ struct AIQuotaApp: App {
                     viewModel.recordDailyActiveIfNeeded()
                     viewModel.refreshOnPopoverOpenIfNeeded()
                     let enabled = viewModel.settings.analyticsEnabled
-                    let services = viewModel.analyticsServicesParam
+                    let params = viewModel.analyticsContextParams
                     Task {
                         await AnalyticsClient.shared.send(
                             "popover_opened",
-                            params: ["services": services],
+                            params: params,
                             enabled: enabled
                         )
                     }

--- a/AIQuota/Analytics/AnalyticsClient.swift
+++ b/AIQuota/Analytics/AnalyticsClient.swift
@@ -1,15 +1,111 @@
 import Foundation
+import OSLog
+import FirebaseCore
+import FirebaseAnalytics
 
-/// Fire-and-forget GA4 Measurement Protocol client.
-/// All sends are silent no-ops when `enabled` is false or `Analytics.plist` is absent.
-actor AnalyticsClient {
+/// Shared analytics facade.
+///
+/// If a local `GoogleService-Info.plist` is present in the app bundle, events are
+/// routed through Firebase Analytics Core. Otherwise the app falls back to the
+/// existing Measurement Protocol transport so current instrumentation keeps
+/// working until the Firebase app config is added locally.
+final class AnalyticsClient: @unchecked Sendable {
     static let shared = AnalyticsClient()
 
+    private enum Backend {
+        case undetermined
+        case firebase
+        case measurementProtocol
+        case none
+    }
+
+    private let logger = Logger(subsystem: "com.niederme.AIQuota", category: "Analytics")
+    private let fallbackTransport = MeasurementProtocolTransport()
+    private let stateQueue = DispatchQueue(label: "com.niederme.AIQuota.analytics")
+
+    private var backend: Backend = .undetermined
+    private var collectionEnabled = false
+
+    private init() {}
+
+    func bootstrap(initialCollectionEnabled enabled: Bool) {
+        stateQueue.sync {
+            collectionEnabled = enabled
+            configureIfNeededLocked()
+            applyCollectionSettingLocked()
+        }
+    }
+
+    func setCollectionEnabled(_ enabled: Bool) {
+        stateQueue.sync {
+            collectionEnabled = enabled
+            configureIfNeededLocked()
+            applyCollectionSettingLocked()
+        }
+    }
+
+    func send(_ eventName: String, params: [String: String] = [:], enabled: Bool) async {
+        let backend = stateQueue.sync { () -> Backend in
+            collectionEnabled = enabled
+            configureIfNeededLocked()
+            applyCollectionSettingLocked()
+            return enabled ? self.backend : .none
+        }
+
+        switch backend {
+        case .firebase:
+            let parameters = params.reduce(into: [String: Any]()) { partialResult, pair in
+                partialResult[pair.key] = pair.value
+            }
+            Analytics.logEvent(eventName, parameters: parameters.isEmpty ? nil : parameters)
+        case .measurementProtocol:
+            await fallbackTransport.send(eventName, params: params, enabled: true)
+        case .none, .undetermined:
+            return
+        }
+    }
+
+    private func configureIfNeededLocked() {
+        guard backend == .undetermined else { return }
+
+        if Bundle.main.url(forResource: "GoogleService-Info", withExtension: "plist") != nil {
+            if FirebaseApp.app() == nil {
+                FirebaseApp.configure()
+            }
+            backend = .firebase
+            logger.notice("Analytics backend: Firebase")
+            return
+        }
+
+        if fallbackTransport.isConfigured {
+            backend = .measurementProtocol
+            logger.notice("Analytics backend: Measurement Protocol fallback")
+            return
+        }
+
+        backend = .none
+        logger.notice("Analytics backend unavailable: no Firebase or fallback configuration")
+    }
+
+    private func applyCollectionSettingLocked() {
+        guard backend == .firebase else { return }
+
+        Analytics.setAnalyticsCollectionEnabled(collectionEnabled)
+        Analytics.setUserProperty("NO", forName: AnalyticsUserPropertyAllowAdPersonalizationSignals)
+    }
+}
+
+private final class MeasurementProtocolTransport {
+    private let logger = Logger(subsystem: "com.niederme.AIQuota", category: "AnalyticsFallback")
     private let firebaseAppID: String?
     private let apiSecret: String?
     private let instanceID: String
 
-    private init() {
+    var isConfigured: Bool {
+        firebaseAppID != nil && apiSecret != nil
+    }
+
+    init() {
         if let url = Bundle.main.url(forResource: "Analytics", withExtension: "plist"),
            let plist = NSDictionary(contentsOf: url) {
             firebaseAppID = plist["FirebaseAppID"] as? String
@@ -49,9 +145,16 @@ actor AnalyticsClient {
             "app_instance_id": instanceID,
             "events": [["name": eventName, "params": params]]
         ]
-        guard let data = try? JSONSerialization.data(withJSONObject: body) else { return }
-        request.httpBody = data
 
-        _ = try? await URLSession.shared.data(for: request)
+        do {
+            request.httpBody = try JSONSerialization.data(withJSONObject: body)
+            let (_, response) = try await URLSession.shared.data(for: request)
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200 ..< 300).contains(httpResponse.statusCode) {
+                logger.error("Measurement Protocol send failed for \(eventName, privacy: .public) with status \(httpResponse.statusCode)")
+            }
+        } catch {
+            logger.error("Measurement Protocol send failed for \(eventName, privacy: .public): \(error.localizedDescription, privacy: .public)")
+        }
     }
 }

--- a/AIQuota/Resources/Info.plist
+++ b/AIQuota/Resources/Info.plist
@@ -16,6 +16,12 @@
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
+	<key>FIREBASE_ANALYTICS_COLLECTION_ENABLED</key>
+	<false/>
+	<key>GOOGLE_ANALYTICS_DEFAULT_ALLOW_AD_PERSONALIZATION_SIGNALS</key>
+	<false/>
+	<key>GOOGLE_ANALYTICS_IDFV_COLLECTION_ENABLED</key>
+	<false/>
 	<!-- Menubar-only: suppress Dock icon -->
 	<key>LSUIElement</key>
 	<true/>

--- a/AIQuota/Support/AnalyticsAppDelegate.swift
+++ b/AIQuota/Support/AnalyticsAppDelegate.swift
@@ -1,0 +1,33 @@
+import AppKit
+import AIQuotaKit
+
+final class AnalyticsAppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let settings = SharedDefaults.loadSettings()
+        AnalyticsClient.shared.bootstrap(initialCollectionEnabled: settings.analyticsEnabled)
+
+        let enrolledServices = SharedDefaults.loadEnrolledServices()
+        let services = switch enrolledServices.count {
+        case 0: "none"
+        case 1: enrolledServices.first?.rawValue ?? "none"
+        default: "both"
+        }
+
+        let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+        let onboardingCompleted = UserDefaults.standard.bool(forKey: "onboarding.v1.hasCompleted")
+        Task {
+            await AnalyticsClient.shared.send(
+                "app_launched",
+                params: [
+                    "app_version": appVersion,
+                    "services": services,
+                    "service_count": String(enrolledServices.count),
+                    "menu_bar_service": settings.menuBarService.rawValue,
+                    "notifications_enabled": settings.notifications.enabled ? "true" : "false",
+                    "onboarding_completed": onboardingCompleted ? "true" : "false"
+                ],
+                enabled: settings.analyticsEnabled
+            )
+        }
+    }
+}

--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -47,6 +47,7 @@ final class QuotaViewModel {
     // MARK: - Shared state
 
     var settings: AppSettings = SharedDefaults.loadSettings()
+    private var lastSavedSettings: AppSettings = SharedDefaults.loadSettings()
     /// Which service's panel is visible in the popover.
     var activeService: ServiceType = .codex
 
@@ -71,6 +72,10 @@ final class QuotaViewModel {
     /// so clicking the menu bar icon repeatedly doesn't re-open it.
     private(set) var onboardingTriggeredThisSession = false
 
+    private var hasCompletedOnboarding: Bool {
+        UserDefaults.standard.bool(forKey: "onboarding.v1.hasCompleted")
+    }
+
     func markOnboardingTriggered() {
         onboardingTriggeredThisSession = true
     }
@@ -78,9 +83,13 @@ final class QuotaViewModel {
     func completeOnboarding() {
         UserDefaults.standard.set(true, forKey: "onboarding.v1.hasCompleted")
         onboardingTriggeredThisSession = true
-        Task {
-            await AnalyticsClient.shared.send("onboarding_completed", enabled: settings.analyticsEnabled)
-        }
+        trackAnalytics(
+            "onboarding_completed",
+            extraParams: [
+                "completed_from": "guided_setup",
+                "has_connected_service": boolString(!enrolledServices.isEmpty)
+            ]
+        )
     }
 
     /// "codex", "claude", "both", or "none" — used as an analytics param.
@@ -92,15 +101,23 @@ final class QuotaViewModel {
         }
     }
 
+    var analyticsContextParams: [String: String] {
+        [
+            "services": analyticsServicesParam,
+            "service_count": String(enrolledServices.count),
+            "active_service": activeService.rawValue,
+            "menu_bar_service": settings.menuBarService.rawValue,
+            "notifications_enabled": boolString(settings.notifications.enabled),
+            "onboarding_completed": boolString(hasCompletedOnboarding)
+        ]
+    }
+
     func recordDailyActiveIfNeeded() {
         let today = String(ISO8601DateFormatter().string(from: Date()).prefix(10))
         let key = "analytics.lastActiveDate"
         guard UserDefaults.standard.string(forKey: key) != today else { return }
         UserDefaults.standard.set(today, forKey: key)
-        let enabled = settings.analyticsEnabled
-        Task {
-            await AnalyticsClient.shared.send("app_active", enabled: enabled)
-        }
+        trackAnalytics("app_active", extraParams: ["surface": "popover"])
     }
 
     func resetOnboardingForReplay() {
@@ -209,6 +226,7 @@ final class QuotaViewModel {
                     if state == .authenticated && !self.enrolledServices.contains(.claude) {
                         self.enrolledServices.insert(.claude)
                         SharedDefaults.enrollService(.claude)
+                        self.trackServiceConnected(.claude)
                     }
                     if state == .authenticated && self.refreshTask == nil {
                         self.startAutoRefresh()
@@ -229,13 +247,7 @@ final class QuotaViewModel {
                     if state == .authenticated && !self.enrolledServices.contains(.codex) {
                         self.enrolledServices.insert(.codex)
                         SharedDefaults.enrollService(.codex)
-                        Task {
-                            await AnalyticsClient.shared.send(
-                                "service_connected",
-                                params: ["service_name": "codex"],
-                                enabled: self.settings.analyticsEnabled
-                            )
-                        }
+                        self.trackServiceConnected(.codex)
                     }
                     if state == .authenticated && self.refreshTask == nil {
                         self.startAutoRefresh()
@@ -604,15 +616,7 @@ final class QuotaViewModel {
         isCodexLoading = false
         isClaudeLoading = false
         startAutoRefresh()
-        let enabled = settings.analyticsEnabled
-        let services = analyticsServicesParam
-        Task {
-            await AnalyticsClient.shared.send(
-                "manual_refresh",
-                params: ["services": services],
-                enabled: enabled
-            )
-        }
+        trackAnalytics("manual_refresh")
     }
 
     /// Refresh on menu bar popover open when the cached data is missing or stale,
@@ -656,13 +660,7 @@ final class QuotaViewModel {
             if !enrolledServices.contains(.claude) {
                 enrolledServices.insert(.claude)
                 SharedDefaults.enrollService(.claude)
-                Task {
-                    await AnalyticsClient.shared.send(
-                        "service_connected",
-                        params: ["service_name": "claude"],
-                        enabled: settings.analyticsEnabled
-                    )
-                }
+                trackServiceConnected(.claude)
             }
             await refreshClaude()
             if refreshTask == nil { startAutoRefresh() }
@@ -677,6 +675,7 @@ final class QuotaViewModel {
             try? await codexCoordinator.signOut()
             self.enrolledServices.remove(.codex)
             SharedDefaults.unenrollService(.codex)
+            self.trackServiceDisconnected(.codex)
             // If menuBarService is now unenrolled, correct it
             if !self.enrolledServices.contains(self.settings.menuBarService),
                let fallback = self.enrolledServices.first {
@@ -692,6 +691,7 @@ final class QuotaViewModel {
             try? await claudeCoordinator.signOut()
             self.enrolledServices.remove(.claude)
             SharedDefaults.unenrollService(.claude)
+            self.trackServiceDisconnected(.claude)
             if !self.enrolledServices.contains(self.settings.menuBarService),
                let fallback = self.enrolledServices.first {
                 self.settings.menuBarService = fallback
@@ -704,8 +704,57 @@ final class QuotaViewModel {
     // MARK: - Settings
 
     func saveSettings() {
+        let previous = lastSavedSettings
         SharedDefaults.saveSettings(settings)
+        if !previous.analyticsEnabled && settings.analyticsEnabled {
+            trackAnalytics(
+                "analytics_enabled",
+                extraParams: [
+                    "consent_surface": hasCompletedOnboarding ? "settings" : "onboarding",
+                    "has_connected_service": boolString(!enrolledServices.isEmpty)
+                ],
+                enabledOverride: true
+            )
+        }
+        AnalyticsClient.shared.setCollectionEnabled(settings.analyticsEnabled)
+        lastSavedSettings = settings
         if isCodexAuthenticated || isClaudeAuthenticated { startAutoRefresh() }
+    }
+
+    private func trackServiceConnected(_ service: ServiceType) {
+        trackAnalytics(
+            "service_connected",
+            extraParams: [
+                "service": service.rawValue,
+                "services_after_connect": analyticsServicesParam
+            ]
+        )
+    }
+
+    private func trackServiceDisconnected(_ service: ServiceType) {
+        trackAnalytics(
+            "service_disconnected",
+            extraParams: [
+                "service": service.rawValue,
+                "services_after_disconnect": analyticsServicesParam
+            ]
+        )
+    }
+
+    private func trackAnalytics(
+        _ eventName: String,
+        extraParams: [String: String] = [:],
+        enabledOverride: Bool? = nil
+    ) {
+        let enabled = enabledOverride ?? settings.analyticsEnabled
+        let params = analyticsContextParams.merging(extraParams) { _, new in new }
+        Task {
+            await AnalyticsClient.shared.send(eventName, params: params, enabled: enabled)
+        }
+    }
+
+    private func boolString(_ value: Bool) -> String {
+        value ? "true" : "false"
     }
 
 }

--- a/AIQuota/Views/CircularGaugeView.swift
+++ b/AIQuota/Views/CircularGaugeView.swift
@@ -20,8 +20,8 @@ struct CircularGaugeView: View {
     let label: String
     let primaryLabel: String   // e.g. "5h"
     let secondaryLabel: String // e.g. "7-day"
-    let resetSeconds: Int
-    let weeklyResetSeconds: Int
+    let resetAt: Date?
+    let weeklyResetAt: Date?
     let isRefreshing: Bool
     let onRefresh: () -> Void
 
@@ -150,14 +150,14 @@ struct CircularGaugeView: View {
                 .font(.headline.bold())
                 .foregroundStyle(primaryLimitReached ? .red : .primary)
 
-            Text(primaryLimitReached ? "\(primaryLabel) limit reached · \(primaryLimitCountdownText)" : primaryCountdownText)
+            Text(primaryCountdownText)
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(primaryLimitReached ? AnyShapeStyle(.red.opacity(0.8)) : AnyShapeStyle(.tertiary))
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
 
             if !isLoading && (secondaryPercent >= 85 || secondaryLimitReached) {
-                Text(secondaryLimitReached ? "\(secondaryLabel) limit reached · \(secondaryLimitCountdownText)" : secondaryCountdownText)
+                Text(secondaryCountdownText)
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(secondaryLimitReached ? AnyShapeStyle(.red.opacity(0.8)) : AnyShapeStyle(.tertiary))
                     .lineLimit(1)
@@ -167,19 +167,11 @@ struct CircularGaugeView: View {
     }
 
     private var primaryCountdownText: String {
-        "\(primaryLabel) reset in \(CountdownTextFormatter.duration(resetSeconds, style: .compact))"
-    }
-
-    private var primaryLimitCountdownText: String {
-        "resets in \(CountdownTextFormatter.duration(resetSeconds, style: .compact))"
+        ResetTimeTextFormatter.windowCaption(primaryLabel, resetAt: resetAt)
     }
 
     private var secondaryCountdownText: String {
-        "\(secondaryLabel) reset in \(CountdownTextFormatter.duration(weeklyResetSeconds, style: .compact))"
-    }
-
-    private var secondaryLimitCountdownText: String {
-        "resets in \(CountdownTextFormatter.duration(weeklyResetSeconds, style: .compact))"
+        ResetTimeTextFormatter.windowCaption(secondaryLabel, resetAt: weeklyResetAt)
     }
 }
 

--- a/AIQuota/Views/CircularGaugeView.swift
+++ b/AIQuota/Views/CircularGaugeView.swift
@@ -152,6 +152,7 @@ struct CircularGaugeView: View {
 
             Text(primaryCountdownText)
                 .font(.system(size: 11, weight: .medium))
+                .monospacedDigit()
                 .foregroundStyle(primaryLimitReached ? AnyShapeStyle(.red.opacity(0.8)) : AnyShapeStyle(.tertiary))
                 .lineLimit(1)
                 .minimumScaleFactor(0.8)
@@ -159,6 +160,7 @@ struct CircularGaugeView: View {
             if !isLoading && (secondaryPercent >= 85 || secondaryLimitReached) {
                 Text(secondaryCountdownText)
                     .font(.system(size: 11, weight: .medium))
+                    .monospacedDigit()
                     .foregroundStyle(secondaryLimitReached ? AnyShapeStyle(.red.opacity(0.8)) : AnyShapeStyle(.tertiary))
                     .lineLimit(1)
                     .minimumScaleFactor(0.8)

--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -96,8 +96,8 @@ struct PopoverView: View {
                     label: "Codex",
                     primaryLabel: formatWindowDuration(u.hourlyWindowSeconds),
                     secondaryLabel: "7d",
-                    resetSeconds: u.hourlyResetAfterSeconds,
-                    weeklyResetSeconds: u.weeklyResetAfterSeconds,
+                    resetAt: u.hourlyResetAt == .distantFuture ? nil : u.hourlyResetAt,
+                    weeklyResetAt: u.weeklyResetAt == .distantFuture ? nil : u.weeklyResetAt,
                     isRefreshing: viewModel.isCodexLoading,
                     onRefresh: { viewModel.manualRefresh() }
                 )
@@ -108,7 +108,7 @@ struct PopoverView: View {
                     secondaryPercent: 0, secondaryLimitReached: false,
                     isLoading: true, icon: "logo-openai",
                     label: "Codex", primaryLabel: "5h", secondaryLabel: "7d",
-                    resetSeconds: 0, weeklyResetSeconds: 0, isRefreshing: true, onRefresh: {}
+                    resetAt: nil, weeklyResetAt: nil, isRefreshing: true, onRefresh: {}
                 )
             }
         } else {
@@ -132,8 +132,8 @@ struct PopoverView: View {
                     label: "Claude Code",
                     primaryLabel: "5h",
                     secondaryLabel: "7d",
-                    resetSeconds: u.resetAfterSeconds,
-                    weeklyResetSeconds: u.sevenDayResetAfterSeconds,
+                    resetAt: u.fiveHourResetsAt,
+                    weeklyResetAt: u.sevenDayResetsAt,
                     isRefreshing: viewModel.isClaudeLoading,
                     onRefresh: { viewModel.manualRefresh() }
                 )
@@ -144,7 +144,7 @@ struct PopoverView: View {
                     secondaryPercent: 0, secondaryLimitReached: false,
                     isLoading: true, icon: "logo-claude",
                     label: "Claude Code", primaryLabel: "5h", secondaryLabel: "7d",
-                    resetSeconds: 0, weeklyResetSeconds: 0, isRefreshing: true, onRefresh: {}
+                    resetAt: nil, weeklyResetAt: nil, isRefreshing: true, onRefresh: {}
                 )
             }
         } else {

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -46,10 +46,13 @@ struct SettingsView: View {
                     )
                     .onChange(of: vm.settings.menuBarService) { _, newValue in
                         let enabled = vm.settings.analyticsEnabled
+                        let params = vm.analyticsContextParams.merging(
+                            ["service": newValue.rawValue]
+                        ) { _, new in new }
                         Task {
                             await AnalyticsClient.shared.send(
                                 "menubar_service_changed",
-                                params: ["service": newValue.rawValue],
+                                params: params,
                                 enabled: enabled
                             )
                         }

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Formatting/ResetTimeTextFormatter.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Formatting/ResetTimeTextFormatter.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+public enum ResetTimeTextFormatter {
+    public static func windowCaption(
+        _ windowLabel: String,
+        resetAt: Date?,
+        now: Date = .now,
+        calendar: Calendar = .autoupdatingCurrent,
+        locale: Locale = .autoupdatingCurrent
+    ) -> String {
+        "\(windowLabel) resets \(resetPhrase(resetAt: resetAt, now: now, calendar: calendar, locale: locale))"
+    }
+
+    private static func resetPhrase(
+        resetAt: Date?,
+        now: Date,
+        calendar: Calendar,
+        locale: Locale
+    ) -> String {
+        guard let resetAt, resetAt != .distantFuture, resetAt != .distantPast else {
+            return "soon"
+        }
+
+        if resetAt <= now {
+            return "now"
+        }
+
+        let time = timeText(for: resetAt, locale: locale)
+        if calendar.isDate(resetAt, inSameDayAs: now) {
+            return "today \(time)"
+        }
+
+        if let tomorrow = calendar.date(byAdding: .day, value: 1, to: now),
+           calendar.isDate(resetAt, inSameDayAs: tomorrow) {
+            return "tomorrow \(time)"
+        }
+
+        return "\(weekdayText(for: resetAt, locale: locale)) \(time)"
+    }
+
+    private static func timeText(for date: Date, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("j:mm")
+
+        return formatter.string(from: date)
+            .components(separatedBy: .whitespacesAndNewlines)
+            .joined()
+            .lowercased()
+    }
+
+    private static func weekdayText(for date: Date, locale: Locale) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = locale
+        formatter.setLocalizedDateFormatFromTemplate("EEEE")
+        return formatter.string(from: date)
+    }
+}

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
@@ -52,22 +52,22 @@ struct PopoverTypographyTests {
         let gaugeSource = try String(contentsOf: repoRoot.appending(path: "AIQuota/Views/CircularGaugeView.swift"), encoding: .utf8)
         let popoverSource = try String(contentsOf: repoRoot.appending(path: "AIQuota/Views/PopoverView.swift"), encoding: .utf8)
 
-        // CircularGaugeView: new parameter exists
-        #expect(gaugeSource.contains("weeklyResetSeconds: Int"))
+        // CircularGaugeView: date-based reset parameters exist
+        #expect(gaugeSource.contains("resetAt: Date?"))
+        #expect(gaugeSource.contains("weeklyResetAt: Date?"))
 
-        // CircularGaugeView: captions use the shared countdown formatter
-        #expect(gaugeSource.contains("CountdownTextFormatter.duration(resetSeconds, style: .compact)"))
-        #expect(gaugeSource.contains("CountdownTextFormatter.duration(weeklyResetSeconds, style: .compact)"))
+        // CircularGaugeView: captions use the shared absolute-time formatter
+        #expect(gaugeSource.contains("ResetTimeTextFormatter.windowCaption(primaryLabel, resetAt: resetAt)"))
+        #expect(gaugeSource.contains("ResetTimeTextFormatter.windowCaption(secondaryLabel, resetAt: weeklyResetAt)"))
+        #expect(gaugeSource.contains("Text(primaryCountdownText)"))
+        #expect(gaugeSource.contains("Text(secondaryCountdownText)"))
 
-        // CircularGaugeView: 7d limit reached state
-        #expect(gaugeSource.contains(#""\(secondaryLabel) limit reached · \(secondaryLimitCountdownText)""#))
-
-        // PopoverView: Codex passes real weekly reset seconds and exhaustion state
-        #expect(popoverSource.contains("u.weeklyResetAfterSeconds"))
+        // PopoverView: Codex passes real weekly reset dates and exhaustion state
+        #expect(popoverSource.contains("u.weeklyResetAt"))
         #expect(popoverSource.contains("u.isWeeklyExhausted"))
 
-        // PopoverView: Claude passes real 7-day reset seconds and exhaustion state
-        #expect(popoverSource.contains("u.sevenDayResetAfterSeconds"))
+        // PopoverView: Claude passes real 7-day reset dates and exhaustion state
+        #expect(popoverSource.contains("u.sevenDayResetsAt"))
         #expect(popoverSource.contains("u.sevenDayUtilization >= 100"))
     }
 

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
@@ -21,6 +21,7 @@ struct PopoverTypographyTests {
         #expect(gaugeSource.contains(#".font(.system(size: 13, weight: .medium))"#))
         #expect(gaugeSource.contains(#".font(.system(size: 13, weight: .semibold, design: .rounded))"#))
         #expect(gaugeSource.contains(#".font(.system(size: 11, weight: .medium))"#))
+        #expect(gaugeSource.contains(".monospacedDigit()"))
         #expect(!gaugeSource.contains(#".font(.system(size: 12, weight: .semibold, design: .rounded))"#))
     }
 

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/ResetTimeTextFormatterTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/ResetTimeTextFormatterTests.swift
@@ -1,0 +1,83 @@
+import AIQuotaKit
+import Foundation
+import Testing
+
+@Suite("Reset time text formatter")
+struct ResetTimeTextFormatterTests {
+    private let locale = Locale(identifier: "en_US_POSIX")
+    private let calendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+        return calendar
+    }()
+
+    @Test("same-day resets show today and the local time compactly")
+    func sameDayResetUsesTodayAndTime() {
+        let now = date(year: 2026, month: 4, day: 17, hour: 17, minute: 55)
+        let resetAt = date(year: 2026, month: 4, day: 17, hour: 20, minute: 29)
+
+        let formatted = ResetTimeTextFormatter.windowCaption(
+            "5h",
+            resetAt: resetAt,
+            now: now,
+            calendar: calendar,
+            locale: locale
+        )
+
+        #expect(formatted == "5h resets today 8:29pm")
+    }
+
+    @Test("next-day resets show tomorrow and the local time compactly")
+    func nextDayResetUsesTomorrowAndTime() {
+        let now = date(year: 2026, month: 4, day: 17, hour: 17, minute: 55)
+        let resetAt = date(year: 2026, month: 4, day: 18, hour: 0, minute: 15)
+
+        let formatted = ResetTimeTextFormatter.windowCaption(
+            "5h",
+            resetAt: resetAt,
+            now: now,
+            calendar: calendar,
+            locale: locale
+        )
+
+        #expect(formatted == "5h resets tomorrow 12:15am")
+    }
+
+    @Test("future-day resets show the weekday and time")
+    func futureDayResetUsesWeekdayAndTime() {
+        let now = date(year: 2026, month: 4, day: 17, hour: 17, minute: 55)
+        let resetAt = date(year: 2026, month: 4, day: 22, hour: 13, minute: 3)
+
+        let formatted = ResetTimeTextFormatter.windowCaption(
+            "7d",
+            resetAt: resetAt,
+            now: now,
+            calendar: calendar,
+            locale: locale
+        )
+
+        #expect(formatted == "7d resets Wednesday 1:03pm")
+    }
+
+    @Test("missing reset dates degrade gracefully")
+    func missingResetDateUsesFallback() {
+        let formatted = ResetTimeTextFormatter.windowCaption(
+            "5h",
+            resetAt: nil,
+            locale: locale
+        )
+
+        #expect(formatted == "5h resets soon")
+    }
+
+    private func date(year: Int, month: Int, day: Int, hour: Int, minute: Int) -> Date {
+        calendar.date(from: DateComponents(
+            timeZone: calendar.timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute
+        ))!
+    }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -168,7 +168,8 @@
                   Not by default. AIQuota includes an optional setting called “Help John improve
                   AIQuota with anonymous usage analytics,” and it starts off. If you turn it on,
                   AIQuota sends simple anonymous metrics: app launch, daily active use, app version,
-                  service connection, and onboarding completion. No prompts, tokens, or personal info.
+                  service connection, and onboarding completion. These events may be processed by
+                  Google Firebase Analytics. No prompts, tokens, or personal info.
                 </p>
               </details>
 

--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -58,7 +58,7 @@
         <section class="policy-hero">
           <div class="container policy-container">
             <h1 class="policy-title">Privacy Policy</h1>
-            <p class="policy-date">Last updated: April 7, 2026</p>
+            <p class="policy-date">Last updated: April 17, 2026</p>
           </div>
         </section>
 
@@ -92,7 +92,7 @@
 
               <h2>Optional anonymous analytics</h2>
               <p>AIQuota includes an optional setting called “Help John improve AIQuota with anonymous usage analytics.” This setting is off by default.</p>
-              <p>If you choose to enable it, AIQuota sends simple anonymous product metrics: app launch, daily active use, app version, service connection, and onboarding completion. It does not include prompts, auth tokens, cookies, or personal information.</p>
+              <p>If you choose to enable it, AIQuota sends simple anonymous product metrics: app launch, daily active use, app version, service connection, and onboarding completion. These events may be processed by Google Firebase Analytics. They do not include prompts, auth tokens, cookies, or personal information.</p>
 
               <h2>Where data is stored</h2>
               <p>AIQuota is designed to keep data on-device whenever possible.</p>
@@ -111,6 +111,7 @@
               <ul>
                 <li>OpenAI, when you connect Codex-related quota tracking.</li>
                 <li>Anthropic, when you connect Claude Code quota tracking.</li>
+                <li>Google Firebase Analytics, only if you opt in to anonymous usage analytics.</li>
                 <li>Apple platform services used to run the app, widgets, notifications, and local secure storage.</li>
               </ul>
 

--- a/docs/superpowers/specs/2026-04-17-firebase-analytics-event-plan.md
+++ b/docs/superpowers/specs/2026-04-17-firebase-analytics-event-plan.md
@@ -1,0 +1,55 @@
+# Firebase Analytics Event Plan
+
+Date: April 17, 2026
+
+## Questions This Should Answer
+
+- How many new instrumented installs are we getting?
+- How many active users do we have daily and monthly?
+- How many installs become activated users?
+- Which connected services are people actually using?
+- How often do people come back and manually refresh or open the popover?
+- How many users opt into anonymous analytics?
+
+## Source Of Truth
+
+Built-in Firebase/GA4 events answer:
+
+- `first_open`: new instrumented installs
+- `session_start`: active sessions
+- `user_engagement`: engagement and stickiness
+- `app_update`: version adoption
+
+Custom AIQuota events answer product-specific questions:
+
+| Event | Purpose | Key params |
+| --- | --- | --- |
+| `app_launched` | app-open context | `app_version`, `services`, `service_count`, `menu_bar_service`, `notifications_enabled`, `onboarding_completed` |
+| `app_active` | daily active product use | `surface`, `services`, `service_count`, `active_service`, `menu_bar_service` |
+| `popover_opened` | core product interaction | `services`, `service_count`, `active_service`, `menu_bar_service`, `notifications_enabled` |
+| `manual_refresh` | high-intent usage | `services`, `service_count`, `active_service`, `menu_bar_service` |
+| `service_connected` | activation milestone | `service`, `services_after_connect`, `service_count` |
+| `service_disconnected` | churn / service mix changes | `service`, `services_after_disconnect`, `service_count` |
+| `onboarding_completed` | setup completion | `completed_from`, `has_connected_service`, `services`, `service_count` |
+| `analytics_enabled` | opt-in rate | `consent_surface`, `has_connected_service`, `services`, `service_count` |
+| `menubar_service_changed` | preference / multi-service usage | `service`, `services`, `service_count`, `menu_bar_service` |
+
+## Working Metric Definitions
+
+- `Installs`: GA4 `first_open`
+- `DAU`: GA4 Active Users, optionally cross-checked against custom `app_active`
+- `MAU`: GA4 Active Users over 30 days
+- `Activated installs`: users with either `service_connected` or `onboarding_completed` where `has_connected_service = true`
+- `Analytics opt-in rate`: users with `analytics_enabled`
+
+## Intentional Non-Goals
+
+- No prompts, tokens, cookies, or personal data
+- No `user_id`
+- No ATT / IDFA path
+- No attempt to reconstruct pre-consent onboarding steps
+
+## Notes
+
+- Because analytics consent comes late in onboarding, pre-consent steps are intentionally not tracked.
+- For opt-in users who already connected a service before enabling analytics, `analytics_enabled` plus the `services` params preserves activation context without backfilling hidden events.

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -31,6 +31,7 @@ export PATH="/opt/homebrew/bin:$PATH"
 
 VERSION="${1:?Usage: release.sh <version>}"
 TAG="v${VERSION}"
+SCREENSHOT_SRC=""
 
 # Auto-detect sign_update: prefer $SPARKLE_TOOLS, then DerivedData, then PATH
 if [ -n "${SPARKLE_TOOLS:-}" ]; then


### PR DESCRIPTION
## Summary
- improve popover reset copy to show compact local reset times
- expand optional analytics wiring and update privacy/site copy
- fix the release script screenshot prompt initialization bug

## Verification
- swift test --disable-sandbox --filter ResetTimeTextFormatterTests --filter PopoverTypographyTests
- xcodebuild -project /Users/niederme/~Repos/ai-quota/AIQuota.xcodeproj -scheme AIQuota -sdk macosx build CODE_SIGNING_ALLOWED=NO
- ./scripts/check-site-pages.sh