### PR TITLE
feat: always show 7d reset, popover polish, launch-at-login in onboarding

### DIFF
--- a/AIQuota/Views/CircularGaugeView.swift
+++ b/AIQuota/Views/CircularGaugeView.swift
@@ -34,6 +34,20 @@ struct CircularGaugeView: View {
         return Self.accent
     }
 
+    private static let amber = Color(red: 1.0, green: 0.65, blue: 0.0)
+
+    private var primaryCaptionStyle: AnyShapeStyle {
+        if primaryLimitReached || primaryPercent >= 95 { return AnyShapeStyle(.red.opacity(0.8)) }
+        if primaryPercent >= 85 { return AnyShapeStyle(Self.amber) }
+        return AnyShapeStyle(.secondary)
+    }
+
+    private var secondaryCaptionStyle: AnyShapeStyle {
+        if secondaryLimitReached || secondaryPercent >= 95 { return AnyShapeStyle(.red.opacity(0.8)) }
+        if secondaryPercent >= 85 { return AnyShapeStyle(Self.amber) }
+        return AnyShapeStyle(.secondary)
+    }
+
     private var primaryFill:   Double { isLoading ? 0.5 : Double(max(0, min(100, primaryPercent)))   / 100.0 }
     private var secondaryFill: Double { isLoading ? 0.5 : Double(max(0, min(100, secondaryPercent))) / 100.0 }
     /// Inner ring is always subordinate — same hue, lower opacity.
@@ -109,7 +123,7 @@ struct CircularGaugeView: View {
                                 .contentTransition(.numericText())
                             Text(primaryLabel)
                                 .font(.system(size: 12, weight: .medium))
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(statusColor)
                         }
                         HStack(alignment: .firstTextBaseline, spacing: 3) {
                             Text("\(secondaryPercent)%")
@@ -118,7 +132,7 @@ struct CircularGaugeView: View {
                                 .contentTransition(.numericText())
                             Text(secondaryLabel)
                                 .font(.system(size: 13, weight: .medium))
-                                .foregroundStyle(.tertiary)
+                                .foregroundStyle(statusColor.opacity(0.5))
                         }
                     }
                 }
@@ -151,19 +165,13 @@ struct CircularGaugeView: View {
                 .foregroundStyle(primaryLimitReached ? .red : .primary)
 
             Text(primaryCountdownText)
-                .font(.system(size: 11, weight: .medium))
-                .monospacedDigit()
-                .foregroundStyle(primaryLimitReached ? AnyShapeStyle(.red.opacity(0.8)) : AnyShapeStyle(.tertiary))
-                .lineLimit(1)
-                .minimumScaleFactor(0.8)
+                .font(.caption2)
+                .foregroundStyle(primaryCaptionStyle)
 
-            if !isLoading && (secondaryPercent >= 85 || secondaryLimitReached) {
+            if !isLoading {
                 Text(secondaryCountdownText)
-                    .font(.system(size: 11, weight: .medium))
-                    .monospacedDigit()
-                    .foregroundStyle(secondaryLimitReached ? AnyShapeStyle(.red.opacity(0.8)) : AnyShapeStyle(.tertiary))
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.8)
+                    .font(.caption2)
+                    .foregroundStyle(secondaryCaptionStyle)
             }
         }
     }

--- a/AIQuota/Views/Onboarding/Steps/AnalyticsConsentStepView.swift
+++ b/AIQuota/Views/Onboarding/Steps/AnalyticsConsentStepView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import ServiceManagement
 
 struct AnalyticsConsentStepView: View {
     @Environment(QuotaViewModel.self) private var viewModel
@@ -73,6 +74,11 @@ struct AnalyticsConsentStepView: View {
                 .padding(.trailing, 16)
             }
             .toggleStyle(.switch)
+
+            Divider()
+                .overlay(Color.secondary.opacity(0.12))
+
+            LaunchAtLoginToggle()
 
             Divider()
                 .overlay(Color.secondary.opacity(0.12))

--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -187,16 +187,16 @@ struct PopoverView: View {
                         .padding(.horizontal, 14)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .padding(.vertical, 10)
+                .padding(.vertical, 7)
             } else if hasCodexStats {
                 codexSecondaryStats
                     .padding(.horizontal, 14)
-                    .padding(.vertical, 10)
+                    .padding(.vertical, 7)
                     .frame(maxWidth: .infinity, alignment: .leading)
             } else {
                 claudeSecondaryStats
                     .padding(.horizontal, 14)
-                    .padding(.vertical, 10)
+                    .padding(.vertical, 7)
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
@@ -316,7 +316,7 @@ struct PopoverView: View {
             Text("AIQuota").font(.headline)
             Spacer()
             // Colour key for the dual rings
-            HStack(spacing: 8) {
+            HStack(spacing: 12) {
                 ringKey(label: "5h",    opacity: 1.0)
                 ringKey(label: "7d", opacity: 0.5)
             }
@@ -327,7 +327,7 @@ struct PopoverView: View {
     }
 
     private func ringKey(label: String, opacity: Double) -> some View {
-        HStack(spacing: 4) {
+        HStack(spacing: 2) {
             Circle()
                 .fill(CircularGaugeView.accent.opacity(opacity))
                 .frame(width: 6, height: 6)

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -337,7 +337,7 @@ private struct NotificationStatusRow: View {
 
 // MARK: - Launch at Login
 
-private struct LaunchAtLoginToggle: View {
+struct LaunchAtLoginToggle: View {
     @State private var isEnabled = (SMAppService.mainApp.status == .enabled)
 
     var body: some View {

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Formatting/ResetTimeTextFormatter.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Formatting/ResetTimeTextFormatter.swift
@@ -27,15 +27,15 @@ public enum ResetTimeTextFormatter {
 
         let time = timeText(for: resetAt, locale: locale)
         if calendar.isDate(resetAt, inSameDayAs: now) {
-            return "today \(time)"
+            return "Today \(time)"
         }
 
         if let tomorrow = calendar.date(byAdding: .day, value: 1, to: now),
            calendar.isDate(resetAt, inSameDayAs: tomorrow) {
-            return "tomorrow \(time)"
+            return "Tomorrow \(time)"
         }
 
-        return "\(weekdayText(for: resetAt, locale: locale)) \(time)"
+        return "\(weekdayAbbrev(for: resetAt, calendar: calendar)) \(time)"
     }
 
     private static func timeText(for date: Date, locale: Locale) -> String {
@@ -49,10 +49,16 @@ public enum ResetTimeTextFormatter {
             .lowercased()
     }
 
-    private static func weekdayText(for date: Date, locale: Locale) -> String {
-        let formatter = DateFormatter()
-        formatter.locale = locale
-        formatter.setLocalizedDateFormatFromTemplate("EEEE")
-        return formatter.string(from: date)
+    private static func weekdayAbbrev(for date: Date, calendar: Calendar) -> String {
+        switch calendar.component(.weekday, from: date) {
+        case 1: return "Sun."
+        case 2: return "Mon."
+        case 3: return "Tues."
+        case 4: return "Wed."
+        case 5: return "Thurs."
+        case 6: return "Fri."
+        case 7: return "Sat."
+        default: return ""
+        }
     }
 }

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/ResetTimeTextFormatterTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/ResetTimeTextFormatterTests.swift
@@ -24,7 +24,7 @@ struct ResetTimeTextFormatterTests {
             locale: locale
         )
 
-        #expect(formatted == "5h resets today 8:29pm")
+        #expect(formatted == "5h resets Today 8:29pm")
     }
 
     @Test("next-day resets show tomorrow and the local time compactly")
@@ -40,7 +40,7 @@ struct ResetTimeTextFormatterTests {
             locale: locale
         )
 
-        #expect(formatted == "5h resets tomorrow 12:15am")
+        #expect(formatted == "5h resets Tomorrow 12:15am")
     }
 
     @Test("future-day resets show the weekday and time")
@@ -56,7 +56,7 @@ struct ResetTimeTextFormatterTests {
             locale: locale
         )
 
-        #expect(formatted == "7d resets Wednesday 1:03pm")
+        #expect(formatted == "7d resets Wed. 1:03pm")
     }
 
     @Test("missing reset dates degrade gracefully")


### PR DESCRIPTION
## Summary

- **Always show 7d reset time** under each gauge caption (was only shown at ≥85%)
- **Day abbreviations**: Mon., Tues., Wed., Thurs., Fri., Sat., Sun. with capitalised Today/Tomorrow
- **Reset time typography**: `caption2` regular, `.secondary` color, escalates to amber/red at the same thresholds as the rings
- **5h/7d labels** inside the gauge center now track `statusColor` (purple → amber → red) instead of staying gray
- **Stats row padding** tightened 10→7pt (empty space was left from removing the old 7-day % row)
- **Ring key spacing**: dot sits closer to its label (4→2pt), more breathing room between the two blocks (8→12pt)
- **Launch at Login** toggle added to the onboarding analytics step

## Test plan

- [ ] Both reset lines visible under each gauge at all usage levels
- [ ] Day abbreviations correct for all 7 weekdays; Today/Tomorrow capitalize correctly
- [ ] Reset lines stay `.secondary` below 85%, shift amber at 85%, red at limit
- [ ] 5h/7d labels inside gauge match ring color
- [ ] Stats row looks compact but grows with more content
- [ ] Launch at Login toggle appears in onboarding analytics step and persists correctly