### PR TITLE
chore: migrate Client logging to OSLog + fix stuck-loading on first-launch decode error

### DIFF
--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -452,10 +452,14 @@ final class QuotaViewModel {
                 logger.info("[CodexRefresh] suppressing networkUnavailable: pathMonitor not ready yet")
                 return
             } else if case .decodingError = e {
-                // Transient decode failure (e.g. server returned an error page during
-                // post-reboot network init). Let the next auto-refresh recover silently.
-                logger.info("[CodexRefresh] suppressing decodingError — will retry on next cycle")
-                return
+                // Suppress only when we already have usage data — treats it as a transient
+                // blip (e.g. server returned an error page during post-reboot network init).
+                // If codexUsage is still nil we've never loaded successfully, so surface the
+                // error rather than leaving the gauge stuck in a permanent loading state.
+                if codexUsage != nil {
+                    logger.info("[CodexRefresh] suppressing decodingError — will retry on next cycle")
+                    return
+                }
             }
             codexError = e
         } catch is CancellationError {
@@ -513,10 +517,14 @@ final class QuotaViewModel {
                 logger.info("[ClaudeRefresh] suppressing networkUnavailable: pathMonitor not ready yet")
                 return
             } else if case .decodingError = e {
-                // Transient decode failure (e.g. server returned an error page during
-                // post-reboot network init). Let the next auto-refresh recover silently.
-                logger.info("[ClaudeRefresh] suppressing decodingError — will retry on next cycle")
-                return
+                // Suppress only when we already have usage data — treats it as a transient
+                // blip (e.g. server returned an error page during post-reboot network init).
+                // If claudeUsage is still nil we've never loaded successfully, so surface the
+                // error rather than leaving the gauge stuck in a permanent loading state.
+                if claudeUsage != nil {
+                    logger.info("[ClaudeRefresh] suppressing decodingError — will retry on next cycle")
+                    return
+                }
             }
             claudeError = e
         } catch is CancellationError {

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeClient.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeClient.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 // MARK: - ClaudeClient
 
@@ -27,6 +28,7 @@ public actor ClaudeClient {
     private let coordinator: ClaudeAuthCoordinator
     private let session: URLSession
     private let baseURL = URL(string: "https://claude.ai")!
+    private let logger = Logger(subsystem: "app.aiquota", category: "ClaudeClient")
 
     public init(coordinator: ClaudeAuthCoordinator) {
         self.coordinator = coordinator
@@ -58,14 +60,15 @@ public actor ClaudeClient {
         do {
             (data, response) = try await session.data(for: req)
         } catch {
-            print("[ClaudeClient] ❌ session error: \(error)")
+            logger.error("[ClaudeClient] session error: \(error)")
             throw error
         }
 
         let status = (response as? HTTPURLResponse)?.statusCode ?? -1
-        print("[ClaudeClient] GET \(path) → HTTP \(status)")
+        logger.info("[ClaudeClient] GET \(path) → HTTP \(status)")
         if status != 200 {
-            print("[ClaudeClient] response headers: \((response as? HTTPURLResponse)?.allHeaderFields ?? [:])")
+            let headers = (response as? HTTPURLResponse)?.allHeaderFields ?? [:]
+            logger.warning("[ClaudeClient] non-200 headers: \(headers as NSDictionary)")
         }
 
         try checkStatus(response, data: data)
@@ -74,8 +77,8 @@ public actor ClaudeClient {
             let raw = try Self.decoder.decode(ClaudeUsageResponse.self, from: data)
             return buildUsage(from: raw)
         } catch {
-            let preview = String(data: data.prefix(800), encoding: .utf8) ?? "<non-utf8>"
-            print("[ClaudeClient] decode error: \(error)\nResponse body: \(preview)")
+            let preview = String(data: data.prefix(2000), encoding: .utf8) ?? "<non-utf8>"
+            logger.error("[ClaudeClient] decodingError: \(error) | body: \(preview)")
             throw NetworkError.decodingError(underlying: error)
         }
     }

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/OpenAIClient.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/OpenAIClient.swift
@@ -1,6 +1,8 @@
 import Foundation
+import OSLog
 
 public actor OpenAIClient {
+    private let logger = Logger(subsystem: "app.aiquota", category: "OpenAIClient")
     private let coordinator: CodexAuthCoordinator
     private let session: URLSession
 
@@ -50,6 +52,8 @@ public actor OpenAIClient {
             let raw = try decoder.decode(WhamUsageResponse.self, from: data)
             return CodexUsage(from: raw)
         } catch {
+            let preview = String(data: data.prefix(2000), encoding: .utf8) ?? "<non-UTF8>"
+            logger.error("[OpenAIClient] decodingError: \(error) | body: \(preview)")
             throw NetworkError.decodingError(underlying: error)
         }
     }


### PR DESCRIPTION
## Summary

- **Logger migration**: replace `print()` in `OpenAIClient` and `ClaudeClient` with `OSLog.Logger` (subsystem `app.aiquota`, per-class category). Logs now route through the unified logging system, respect privacy redaction, and are filterable in Console.app.
- **Bigger error body preview**: bump decode-error response body preview from 800 → 2000 chars in both clients to make malformed-response diagnoses much easier post-mortem.
- **Bug fix — stuck-loading on first-launch decode error**: `QuotaViewModel` was blanket-suppressing transient `decodingError` to avoid scary banners during post-reboot network init. But on a brand-new launch where the *first* decode fails, suppression left the gauge stuck in the loading state forever with no visible error. Suppression is now conditional on `codexUsage` / `claudeUsage` being non-nil — so first-load failures surface as banners while in-flight blips stay silent.

## Test plan

- [ ] Build `AIQuota` scheme — confirm `import OSLog` compiles cleanly
- [ ] Open Console.app, filter by subsystem `app.aiquota` — confirm log messages appear with correct categories (`OpenAIClient`, `ClaudeClient`)
- [ ] Manually trigger a decode error (e.g. point client at a bad endpoint) on first launch — confirm an error banner shows up rather than the gauge spinning indefinitely
- [ ] Trigger the same decode error after usage data has loaded once — confirm it's silently suppressed (no banner) and next refresh recovers