### PR TITLE
feat: budget strip + low-balance credits tint for the popover

### DIFF
--- a/AIQuota.xcodeproj/project.pbxproj
+++ b/AIQuota.xcodeproj/project.pbxproj
@@ -22,8 +22,6 @@
 		72ED593D13B133B274DE2113 /* WelcomeStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872D4B7AB7221C3A55960CE1 /* WelcomeStepView.swift */; };
 		7301F858542C589FF8A78E37 /* UpdaterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3CDEE9A5B7D5B416193D23 /* UpdaterViewModel.swift */; };
 		779B5BCC2EBC1AC187C561A5 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 716B00F14F1370CDAC33B5EB /* SettingsView.swift */; };
-		7FC7023A34574E128139E41C /* Analytics.plist in Resources */ = {isa = PBXBuildFile; fileRef = 095F7EB6636590F35E245E34 /* Analytics.plist */; };
-		8A678576DAF63D66580896B2 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 86DF6785AE8D42F76729C72B /* GoogleService-Info.plist */; };
 		924F0EB6579EBF80E4C0FF46 /* WidgetIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F1F18DB5A7FD4515D863D71 /* WidgetIntent.swift */; };
 		92585202E96046BAB9CFF37E /* QuotaTimelineProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACD5E0D36B8FCEF6F2E97EFA /* QuotaTimelineProvider.swift */; };
 		94EB3B6AC94DDB40E367306C /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDE2263EBEB7008EF6988081 /* WebKit.framework */; };
@@ -43,6 +41,7 @@
 		E35629D70F3650759EDF8865 /* ServicesStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C66610C3B005AD239F7EDE75 /* ServicesStepView.swift */; };
 		F15449DA517BF7C4B79320DC /* PopoverView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B4A02F2F3618A00A9FE938 /* PopoverView.swift */; };
 		F2F0EB0760448D88611066A4 /* WidgetSmallView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA7E1FF303A5852FC6BCC6 /* WidgetSmallView.swift */; };
+		F3545CC3A5D937C4E3F40A3A /* BudgetStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8078C57920AA96E74607EA71 /* BudgetStripView.swift */; };
 		F6564018685503ADEE6165C2 /* DoneStepView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20C382E39D030AC581CA9B4 /* DoneStepView.swift */; };
 		FC5F1405D182501F5FFAC02C /* AIQuotaWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4392F2EBD4EFDCA51009B2E9 /* AIQuotaWidgetBundle.swift */; };
 /* End PBXBuildFile section */
@@ -74,7 +73,6 @@
 /* Begin PBXFileReference section */
 		05DE0EF729DDBD14B958D28B /* AIQuota.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AIQuota.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		07B0B4CEC9ACF96AC981FA29 /* CircularGaugeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularGaugeView.swift; sourceTree = "<group>"; };
-		095F7EB6636590F35E245E34 /* Analytics.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Analytics.plist; sourceTree = "<group>"; };
 		0CC4153FE01FA354752C247C /* AnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClient.swift; sourceTree = "<group>"; };
 		16BD0A4CB52E425D9A5A6C34 /* AIQuotaKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = AIQuotaKit; path = Packages/AIQuotaKit; sourceTree = SOURCE_ROOT; };
 		1F1F18DB5A7FD4515D863D71 /* WidgetIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetIntent.swift; sourceTree = "<group>"; };
@@ -91,7 +89,7 @@
 		76B773676A8FBADF9E560DB2 /* WidgetMediumView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetMediumView.swift; sourceTree = "<group>"; };
 		76D9EEAA0A27FF50A5E170F4 /* AIQuotaWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = AIQuotaWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AEFC74142619076ED0AB5BA /* WidgetsStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetsStepView.swift; sourceTree = "<group>"; };
-		86DF6785AE8D42F76729C72B /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
+		8078C57920AA96E74607EA71 /* BudgetStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BudgetStripView.swift; sourceTree = "<group>"; };
 		872D4B7AB7221C3A55960CE1 /* WelcomeStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeStepView.swift; sourceTree = "<group>"; };
 		88FA3DF197FD04781EF8C4EF /* NotificationsStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsStepView.swift; sourceTree = "<group>"; };
 		89176CF3C6B8574A223A6E55 /* AnalyticsConsentStepView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsConsentStepView.swift; sourceTree = "<group>"; };
@@ -138,9 +136,7 @@
 		0CF29E076C587EA866F75396 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				095F7EB6636590F35E245E34 /* Analytics.plist */,
 				FB0180B641391BD6AFC75C41 /* Assets.xcassets */,
-				86DF6785AE8D42F76729C72B /* GoogleService-Info.plist */,
 				E012B199A00FF2ABD9B06DA4 /* Info.plist */,
 			);
 			path = Resources;
@@ -218,6 +214,7 @@
 		A8C3442C7767F3787BD134A1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				8078C57920AA96E74607EA71 /* BudgetStripView.swift */,
 				07B0B4CEC9ACF96AC981FA29 /* CircularGaugeView.swift */,
 				4D136AA90C5E64F0E69E5B51 /* CountdownView.swift */,
 				FB657B3EE7EFE0906CC89C7E /* MenuBarIconView.swift */,
@@ -403,10 +400,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7FC7023A34574E128139E41C /* Analytics.plist in Resources */,
 				B634179F85F5BA71ADF5A25D /* AppIcon.icon in Resources */,
 				96ECF77AF4F522CAF9619D23 /* Assets.xcassets in Resources */,
-				8A678576DAF63D66580896B2 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -443,6 +438,7 @@
 				64E9FF14FC1DB51A9FDD0DCB /* AnalyticsAppDelegate.swift in Sources */,
 				C85373188A0821406ACB6164 /* AnalyticsClient.swift in Sources */,
 				1575BAA1F4C10951443BA5C8 /* AnalyticsConsentStepView.swift in Sources */,
+				F3545CC3A5D937C4E3F40A3A /* BudgetStripView.swift in Sources */,
 				BD011637B9A98BF66EB809CD /* CircularGaugeView.swift in Sources */,
 				98F43072074B245C01E279A4 /* CountdownView.swift in Sources */,
 				4BDBDF48A5EC8E1D8DE63AEE /* DemoDriver.swift in Sources */,

--- a/AIQuota/Demo/DemoDriver.swift
+++ b/AIQuota/Demo/DemoDriver.swift
@@ -32,90 +32,137 @@ final class DemoDriver {
     // Tick durations ~1.4–2.2s. Four full 5h cycles.
     // Frame 0 is applied immediately on open — no loading state.
 
+    // MARK: - Claude timeline  (heavier user — faster cycling, 7d climbs to 100%)
+    //
+    // Base ticks: normal 0.5s · amber 0.6s · red 0.7s · reset 0.3s → ~14s total.
+    // ±25% jitter applied in scheduleNextClaude for a natural feel.
+
     private let claudeFrames: [ServiceFrame] = [
         // Cycle 1: 0 → limit → reset  (7d: 0 → 14%)
-        .init(fiveH:   5, sevenD:   2, resetSecs: 15000, weeklyResetDays: 5, tick: 1.4),
-        .init(fiveH:  25, sevenD:   5, resetSecs: 12600, weeklyResetDays: 5, tick: 1.4),
-        .init(fiveH:  52, sevenD:   8, resetSecs:  9000, weeklyResetDays: 5, tick: 1.4),
-        .init(fiveH:  75, sevenD:  11, resetSecs:  4500, weeklyResetDays: 5, tick: 1.4),
-        .init(fiveH:  88, sevenD:  12, resetSecs:  1800, weeklyResetDays: 5, tick: 1.6), // amber
-        .init(fiveH:  96, sevenD:  13, resetSecs:   480, weeklyResetDays: 5, tick: 1.4),
-        .init(fiveH: 100, sevenD:  13, resetSecs: 15120, weeklyResetDays: 5, tick: 2.0), // red
-        .init(fiveH:   0, sevenD:  14, resetSecs: 18000, weeklyResetDays: 5, tick: 0.8), // reset
+        .init(fiveH:   5, sevenD:   2, resetSecs: 15000, weeklyResetDays: 5, tick: 0.5),
+        .init(fiveH:  25, sevenD:   5, resetSecs: 12600, weeklyResetDays: 5, tick: 0.5),
+        .init(fiveH:  52, sevenD:   8, resetSecs:  9000, weeklyResetDays: 5, tick: 0.5),
+        .init(fiveH:  75, sevenD:  11, resetSecs:  4500, weeklyResetDays: 5, tick: 0.5),
+        .init(fiveH:  88, sevenD:  12, resetSecs:  1800, weeklyResetDays: 5, tick: 0.6), // amber
+        .init(fiveH:  96, sevenD:  13, resetSecs:   480, weeklyResetDays: 5, tick: 0.5),
+        .init(fiveH: 100, sevenD:  13, resetSecs: 15120, weeklyResetDays: 5, tick: 0.7), // red
+        .init(fiveH:   0, sevenD:  14, resetSecs: 18000, weeklyResetDays: 5, tick: 0.3), // reset
 
         // Cycle 2: 7d climbs to ~35%
-        .init(fiveH:  14, sevenD:  20, resetSecs: 16200, weeklyResetDays: 4, tick: 1.4),
-        .init(fiveH:  38, sevenD:  24, resetSecs: 13200, weeklyResetDays: 4, tick: 1.4),
-        .init(fiveH:  62, sevenD:  28, resetSecs: 10200, weeklyResetDays: 4, tick: 1.4),
-        .init(fiveH:  85, sevenD:  31, resetSecs:  2700, weeklyResetDays: 4, tick: 1.6), // amber
-        .init(fiveH:  94, sevenD:  32, resetSecs:   540, weeklyResetDays: 4, tick: 1.4),
-        .init(fiveH: 100, sevenD:  33, resetSecs: 15480, weeklyResetDays: 4, tick: 2.0), // red
-        .init(fiveH:   0, sevenD:  35, resetSecs: 18000, weeklyResetDays: 4, tick: 0.8),
+        .init(fiveH:  14, sevenD:  20, resetSecs: 16200, weeklyResetDays: 4, tick: 0.5),
+        .init(fiveH:  38, sevenD:  24, resetSecs: 13200, weeklyResetDays: 4, tick: 0.5),
+        .init(fiveH:  62, sevenD:  28, resetSecs: 10200, weeklyResetDays: 4, tick: 0.5),
+        .init(fiveH:  85, sevenD:  31, resetSecs:  2700, weeklyResetDays: 4, tick: 0.6), // amber
+        .init(fiveH:  94, sevenD:  32, resetSecs:   540, weeklyResetDays: 4, tick: 0.5),
+        .init(fiveH: 100, sevenD:  33, resetSecs: 15480, weeklyResetDays: 4, tick: 0.7), // red
+        .init(fiveH:   0, sevenD:  35, resetSecs: 18000, weeklyResetDays: 4, tick: 0.3),
 
         // Cycle 3: 7d climbs to ~66%
-        .init(fiveH:  18, sevenD:  46, resetSecs: 15900, weeklyResetDays: 3, tick: 1.4),
-        .init(fiveH:  45, sevenD:  53, resetSecs: 12000, weeklyResetDays: 3, tick: 1.4),
-        .init(fiveH:  72, sevenD:  59, resetSecs:  8400, weeklyResetDays: 3, tick: 1.4),
-        .init(fiveH:  87, sevenD:  62, resetSecs:  2100, weeklyResetDays: 3, tick: 1.6), // amber
-        .init(fiveH: 100, sevenD:  64, resetSecs: 15900, weeklyResetDays: 3, tick: 2.0), // red
-        .init(fiveH:   0, sevenD:  66, resetSecs: 18000, weeklyResetDays: 3, tick: 0.8),
+        .init(fiveH:  18, sevenD:  46, resetSecs: 15900, weeklyResetDays: 3, tick: 0.5),
+        .init(fiveH:  45, sevenD:  53, resetSecs: 12000, weeklyResetDays: 3, tick: 0.5),
+        .init(fiveH:  72, sevenD:  59, resetSecs:  8400, weeklyResetDays: 3, tick: 0.5),
+        .init(fiveH:  87, sevenD:  62, resetSecs:  2100, weeklyResetDays: 3, tick: 0.6), // amber
+        .init(fiveH: 100, sevenD:  64, resetSecs: 15900, weeklyResetDays: 3, tick: 0.7), // red
+        .init(fiveH:   0, sevenD:  66, resetSecs: 18000, weeklyResetDays: 3, tick: 0.3),
 
-        // Cycle 4: 7d hits amber on Claude (≥ 85%)
-        .init(fiveH:  22, sevenD:  73, resetSecs: 14400, weeklyResetDays: 2, tick: 1.4),
-        .init(fiveH:  48, sevenD:  79, resetSecs: 11400, weeklyResetDays: 2, tick: 1.4),
-        .init(fiveH:  70, sevenD:  85, resetSecs:  8400, weeklyResetDays: 2, tick: 1.6), // 7d amber — caption appears
-        .init(fiveH:  87, sevenD:  88, resetSecs:  2700, weeklyResetDays: 2, tick: 1.6), // both amber
-        .init(fiveH: 100, sevenD:  90, resetSecs: 16200, weeklyResetDays: 2, tick: 2.0), // red
-        .init(fiveH:   0, sevenD:  92, resetSecs: 18000, weeklyResetDays: 2, tick: 0.8),
+        // Cycle 4: 7d hits amber (≥ 85%), budget strip escalates
+        .init(fiveH:  22, sevenD:  73, resetSecs: 14400, weeklyResetDays: 2, tick: 0.5),
+        .init(fiveH:  48, sevenD:  79, resetSecs: 11400, weeklyResetDays: 2, tick: 0.5),
+        .init(fiveH:  70, sevenD:  85, resetSecs:  8400, weeklyResetDays: 2, tick: 0.6), // 7d amber
+        .init(fiveH:  87, sevenD:  88, resetSecs:  2700, weeklyResetDays: 2, tick: 0.6), // both amber
+        .init(fiveH: 100, sevenD:  90, resetSecs: 16200, weeklyResetDays: 2, tick: 0.7), // red
+        .init(fiveH:   0, sevenD:  92, resetSecs: 18000, weeklyResetDays: 2, tick: 0.3),
 
         // Final: Claude 7d → 100%
-        .init(fiveH:  24, sevenD:  96, resetSecs: 13800, weeklyResetDays: 1, tick: 1.6),
+        .init(fiveH:  24, sevenD:  96, resetSecs: 13800, weeklyResetDays: 1, tick: 0.6),
         // FINAL FRAME — timer halts after this
         .init(fiveH:  36, sevenD: 100, resetSecs: 11400, weeklyResetDays: 1, tick: 86400),
     ]
 
     // MARK: - Codex timeline  (lighter user — slower cycling, 7d climbs to ~80%)
     //
-    // Tick durations ~2.0–2.6s. Three full 5h cycles.
+    // Base ticks: normal 0.5s · amber 0.6s · red 0.7s · reset 0.3s → ~14s total.
+    // ±25% jitter applied in scheduleNextCodex for a natural feel.
 
     private let codexFrames: [ServiceFrame] = [
         // Cycle 1: slow fill — 0 → limit → reset  (7d: 0 → 13%)
-        .init(fiveH:   4, sevenD:   1, resetSecs: 15200, weeklyResetDays: 5, tick: 2.0),
-        .init(fiveH:  16, sevenD:   3, resetSecs: 13800, weeklyResetDays: 5, tick: 2.0),
-        .init(fiveH:  34, sevenD:   6, resetSecs: 11400, weeklyResetDays: 5, tick: 2.0),
-        .init(fiveH:  55, sevenD:   8, resetSecs:  8100, weeklyResetDays: 5, tick: 2.0),
-        .init(fiveH:  74, sevenD:  10, resetSecs:  4500, weeklyResetDays: 5, tick: 2.0),
-        .init(fiveH:  86, sevenD:  11, resetSecs:  1980, weeklyResetDays: 5, tick: 2.2), // amber
-        .init(fiveH:  94, sevenD:  12, resetSecs:   600, weeklyResetDays: 5, tick: 2.0),
-        .init(fiveH: 100, sevenD:  12, resetSecs: 15360, weeklyResetDays: 5, tick: 2.6), // red
-        .init(fiveH:   0, sevenD:  13, resetSecs: 18000, weeklyResetDays: 5, tick: 1.0),
+        .init(fiveH:   4, sevenD:   1, resetSecs: 15200, weeklyResetDays: 5, tick: 0.5),
+        .init(fiveH:  16, sevenD:   3, resetSecs: 13800, weeklyResetDays: 5, tick: 0.5),
+        .init(fiveH:  34, sevenD:   6, resetSecs: 11400, weeklyResetDays: 5, tick: 0.5),
+        .init(fiveH:  55, sevenD:   8, resetSecs:  8100, weeklyResetDays: 5, tick: 0.5),
+        .init(fiveH:  74, sevenD:  10, resetSecs:  4500, weeklyResetDays: 5, tick: 0.5),
+        .init(fiveH:  86, sevenD:  11, resetSecs:  1980, weeklyResetDays: 5, tick: 0.6), // amber
+        .init(fiveH:  94, sevenD:  12, resetSecs:   600, weeklyResetDays: 5, tick: 0.5),
+        .init(fiveH: 100, sevenD:  12, resetSecs: 15360, weeklyResetDays: 5, tick: 0.7), // red
+        .init(fiveH:   0, sevenD:  13, resetSecs: 18000, weeklyResetDays: 5, tick: 0.3),
 
         // Cycle 2: 7d climbs to ~30%
-        .init(fiveH:   9, sevenD:  18, resetSecs: 16200, weeklyResetDays: 4, tick: 2.0),
-        .init(fiveH:  26, sevenD:  22, resetSecs: 13500, weeklyResetDays: 4, tick: 2.0),
-        .init(fiveH:  48, sevenD:  25, resetSecs: 10800, weeklyResetDays: 4, tick: 2.0),
-        .init(fiveH:  68, sevenD:  27, resetSecs:  7200, weeklyResetDays: 4, tick: 2.0),
-        .init(fiveH:  82, sevenD:  29, resetSecs:  3060, weeklyResetDays: 4, tick: 2.2), // amber
-        .init(fiveH:  96, sevenD:  30, resetSecs:   360, weeklyResetDays: 4, tick: 2.0),
-        .init(fiveH: 100, sevenD:  30, resetSecs: 15600, weeklyResetDays: 4, tick: 2.6), // red
-        .init(fiveH:   0, sevenD:  32, resetSecs: 18000, weeklyResetDays: 4, tick: 1.0),
+        .init(fiveH:   9, sevenD:  18, resetSecs: 16200, weeklyResetDays: 4, tick: 0.5),
+        .init(fiveH:  26, sevenD:  22, resetSecs: 13500, weeklyResetDays: 4, tick: 0.5),
+        .init(fiveH:  48, sevenD:  25, resetSecs: 10800, weeklyResetDays: 4, tick: 0.5),
+        .init(fiveH:  68, sevenD:  27, resetSecs:  7200, weeklyResetDays: 4, tick: 0.5),
+        .init(fiveH:  82, sevenD:  29, resetSecs:  3060, weeklyResetDays: 4, tick: 0.6), // amber
+        .init(fiveH:  96, sevenD:  30, resetSecs:   360, weeklyResetDays: 4, tick: 0.5),
+        .init(fiveH: 100, sevenD:  30, resetSecs: 15600, weeklyResetDays: 4, tick: 0.7), // red
+        .init(fiveH:   0, sevenD:  32, resetSecs: 18000, weeklyResetDays: 4, tick: 0.3),
 
         // Cycle 3: 7d climbs to ~62%
-        .init(fiveH:  11, sevenD:  42, resetSecs: 15600, weeklyResetDays: 3, tick: 2.0),
-        .init(fiveH:  30, sevenD:  48, resetSecs: 13200, weeklyResetDays: 3, tick: 2.0),
-        .init(fiveH:  52, sevenD:  54, resetSecs:  9900, weeklyResetDays: 3, tick: 2.0),
-        .init(fiveH:  74, sevenD:  58, resetSecs:  5400, weeklyResetDays: 3, tick: 2.0),
-        .init(fiveH:  86, sevenD:  60, resetSecs:  2160, weeklyResetDays: 3, tick: 2.2), // amber
-        .init(fiveH:  97, sevenD:  61, resetSecs:   300, weeklyResetDays: 3, tick: 2.0),
-        .init(fiveH: 100, sevenD:  62, resetSecs: 16200, weeklyResetDays: 3, tick: 2.6), // red
-        .init(fiveH:   0, sevenD:  63, resetSecs: 18000, weeklyResetDays: 3, tick: 1.0),
+        .init(fiveH:  11, sevenD:  42, resetSecs: 15600, weeklyResetDays: 3, tick: 0.5),
+        .init(fiveH:  30, sevenD:  48, resetSecs: 13200, weeklyResetDays: 3, tick: 0.5),
+        .init(fiveH:  52, sevenD:  54, resetSecs:  9900, weeklyResetDays: 3, tick: 0.5),
+        .init(fiveH:  74, sevenD:  58, resetSecs:  5400, weeklyResetDays: 3, tick: 0.5),
+        .init(fiveH:  86, sevenD:  60, resetSecs:  2160, weeklyResetDays: 3, tick: 0.6), // amber
+        .init(fiveH:  97, sevenD:  61, resetSecs:   300, weeklyResetDays: 3, tick: 0.5),
+        .init(fiveH: 100, sevenD:  62, resetSecs: 16200, weeklyResetDays: 3, tick: 0.7), // red
+        .init(fiveH:   0, sevenD:  63, resetSecs: 18000, weeklyResetDays: 3, tick: 0.3),
 
         // Final approach: Codex 7d → 80%
-        .init(fiveH:  14, sevenD:  70, resetSecs: 15000, weeklyResetDays: 2, tick: 2.2),
-        .init(fiveH:  22, sevenD:  76, resetSecs: 12600, weeklyResetDays: 2, tick: 2.2),
+        .init(fiveH:  14, sevenD:  70, resetSecs: 15000, weeklyResetDays: 2, tick: 0.6),
+        .init(fiveH:  22, sevenD:  76, resetSecs: 12600, weeklyResetDays: 2, tick: 0.6),
         // FINAL FRAME — timer halts after this
         .init(fiveH:  28, sevenD:  80, resetSecs: 11700, weeklyResetDays: 2, tick: 86400),
     ]
+
+    // MARK: - Extra-usage progression (mirrors Claude timeline cycle indices)
+    //
+    // Cycles 1–2: no extra usage (Pro plan, strip hidden).
+    // Cycle 3 onwards: Max plan, extra usage climbs from ~55% → ~92%,
+    // triggering the budget strip at ≥ 70% and escalating to red at ≥ 85%.
+
+    // MARK: - Codex balance progression
+    //
+    // Drains gradually so the demo also showcases the credits row's
+    // amber (< $20) and red (< $5) treatment alongside the Claude strip.
+
+    private let codexBalance: [Int: Double] = {
+        var map: [Int: Double] = [:]
+        // Cycles 1–2: healthy balance, slowly drawing down
+        for i in 0...16   { map[i] = 197.18 - Double(i) * 4 }   // 197 → 133
+        // Cycle 3: still normal but visibly dropping
+        for i in 17...20  { map[i] = 90 - Double(i - 17) * 18 } // 90 → 36
+        // Final approach: amber territory
+        map[21] = 18
+        map[22] = 11
+        // Last frames: red
+        map[23] = 6
+        map[24] = 3
+        map[25] = 1
+        map[26] = 0
+        map[27] = 0
+        return map
+    }()
+
+    private let claudeExtraUsage: [Int: ClaudeUsage.ExtraUsage] = {
+        var map: [Int: ClaudeUsage.ExtraUsage] = [:]
+        // Cycle 3 starts at frame index 15 — moderate usage, below threshold
+        for i in 15...19 { map[i] = .init(isEnabled: true, monthlyLimit: 2000, usedCredits: Double(i - 15) * 55 + 1100, utilization: Double(i - 15) * 3.5 + 55) }
+        // Cycle 4: strip appears (≥ 70%) and climbs toward red (≥ 85%)
+        for i in 20...25 { map[i] = .init(isEnabled: true, monthlyLimit: 2000, usedCredits: Double(i - 20) * 60 + 1400, utilization: Double(i - 20) * 5 + 70) }
+        // Final frames: clearly in the red zone
+        map[26] = .init(isEnabled: true, monthlyLimit: 2000, usedCredits: 1840, utilization: 92)
+        map[27] = .init(isEnabled: true, monthlyLimit: 2000, usedCredits: 1860, utilization: 93)
+        return map
+    }()
 
     // MARK: - State
 
@@ -160,7 +207,8 @@ final class DemoDriver {
 
     private func scheduleNextClaude() {
         guard claudeIndex < claudeFrames.count else { return }
-        let duration = claudeFrames[claudeIndex].tick
+        let base = claudeFrames[claudeIndex].tick
+        let duration = base < 1 ? base * Double.random(in: 0.75...1.25) : base
         claudeTimer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
             Task { @MainActor [weak self] in self?.applyNextClaudeFrame() }
         }
@@ -177,7 +225,7 @@ final class DemoDriver {
             fiveHourResetsAt:    now.addingTimeInterval(TimeInterval(f.resetSecs)),
             sevenDayUtilization: f.sevenD,
             sevenDayResetsAt:    now.addingTimeInterval(TimeInterval(f.weeklyResetDays * 86400)),
-            extraUsage:          nil,
+            extraUsage:          claudeExtraUsage[claudeIndex - 1],
             fetchedAt:           now
         )
 
@@ -194,7 +242,8 @@ final class DemoDriver {
 
     private func scheduleNextCodex() {
         guard codexIndex < codexFrames.count else { return }
-        let duration = codexFrames[codexIndex].tick
+        let base = codexFrames[codexIndex].tick
+        let duration = base < 1 ? base * Double.random(in: 0.75...1.25) : base
         codexTimer = Timer.scheduledTimer(withTimeInterval: duration, repeats: false) { [weak self] _ in
             Task { @MainActor [weak self] in self?.applyNextCodexFrame() }
         }
@@ -217,7 +266,7 @@ final class DemoDriver {
             limitReached:            f.fiveH >= 100,
             allowed:                 f.fiveH < 100,
             planType:                "plus",
-            creditBalance:           197.18,
+            creditBalance:           codexBalance[codexIndex - 1] ?? 197.18,
             approxLocalMessages:     nil,
             approxCloudMessages:     nil,
             fetchedAt:               now

--- a/AIQuota/Views/BudgetStripView.swift
+++ b/AIQuota/Views/BudgetStripView.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import AIQuotaKit
+
+struct BudgetStripView: View {
+    let extra: ClaudeUsage.ExtraUsage
+
+    static let showThreshold: Double = 70
+
+    private var color: Color {
+        extra.utilization >= 85 ? .red : .orange
+    }
+
+    private var fraction: Double {
+        min(max(extra.utilization / 100.0, 0), 1)
+    }
+
+    /// Abbreviates large limits to "2k" etc. to keep the footer line short.
+    private var usedText: String {
+        let used = Int(extra.usedCredits)
+        let limit = extra.monthlyLimit >= 1000
+            ? "\(extra.monthlyLimit / 1000)k"
+            : "\(extra.monthlyLimit)"
+        return "\(used) / \(limit)"
+    }
+
+    private var resetText: String {
+        let cal = Calendar.current
+        guard
+            let nextMonth = cal.date(byAdding: .month, value: 1, to: .now),
+            let first = cal.date(from: cal.dateComponents([.year, .month], from: nextMonth))
+        else { return "monthly" }
+        return "resets " + first.formatted(.dateTime.month(.abbreviated).day())
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 4) {
+                Text("Extra:")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(usedText)
+                    .font(.caption2.monospacedDigit().bold())
+                    .foregroundStyle(.primary)
+                Spacer(minLength: 4)
+                Text("\(Int(extra.utilization.rounded()))%")
+                    .font(.caption2.monospacedDigit().bold())
+                    .foregroundStyle(color)
+            }
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(.fill.quaternary)
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(color)
+                        .frame(width: geo.size.width * fraction)
+                }
+            }
+            .frame(height: 3)
+
+            Text(resetText)
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 0) {
+        Divider()
+        BudgetStripView(extra: .init(isEnabled: true, monthlyLimit: 2000, usedCredits: 1609, utilization: 80.45))
+            .frame(width: 170)
+        Divider()
+        BudgetStripView(extra: .init(isEnabled: true, monthlyLimit: 2000, usedCredits: 1780, utilization: 89))
+            .frame(width: 170)
+    }
+    .frame(width: 170)
+    .background(.black.opacity(0.85))
+}

--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -281,29 +281,42 @@ struct PopoverView: View {
         if let usage = viewModel.codexUsage {
             VStack(alignment: .leading, spacing: 5) {
                 if let balance = usage.creditBalance {
-                    compactRow("Credits", "\(Int(balance))")
+                    compactRow("Credits", "\(Int(balance))", valueTint: creditTint(balance))
                 }
                 compactRow("Plan", usage.planType.capitalized)
             }
         }
     }
 
+    /// Mirrors the Claude strip's escalation in a balance-based world:
+    /// red below $5 (critical), amber below $20 (running low), normal otherwise.
+    private func creditTint(_ balance: Double) -> Color {
+        if balance < 5 { return .red }
+        if balance < 20 { return .orange }
+        return .primary
+    }
+
     @ViewBuilder
     private var claudeSecondaryStats: some View {
         if let usage = viewModel.claudeUsage {
-            VStack(alignment: .leading, spacing: 5) {
+            VStack(alignment: .leading, spacing: 6) {
                 if let extra = usage.extraUsage, extra.isEnabled {
-                    compactRow("Extra", "\(Int(extra.usedCredits))/\(extra.monthlyLimit)")
+                    if extra.utilization >= BudgetStripView.showThreshold {
+                        BudgetStripView(extra: extra)
+                    } else {
+                        compactRow("Extra", "\(Int(extra.usedCredits))/\(extra.monthlyLimit)")
+                    }
                 }
                 compactRow("Plan", usage.planDisplayName)
             }
         }
     }
 
-    private func compactRow(_ label: String, _ value: String) -> some View {
+    private func compactRow(_ label: String, _ value: String, valueTint: Color = .primary) -> some View {
         HStack(spacing: 5) {
             Text(label + ":").font(.caption2).foregroundStyle(.secondary)
             Text(value).font(.caption2.monospacedDigit().bold())
+                .foregroundStyle(valueTint)
         }
     }
 

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/ClaudeUsage.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/ClaudeUsage.swift
@@ -46,6 +46,13 @@ public struct ClaudeUsage: Codable, Sendable, Equatable {
         public let usedCredits: Double
         /// Percentage of monthly credits consumed, 0–100.
         public let utilization: Double
+
+        public init(isEnabled: Bool, monthlyLimit: Int, usedCredits: Double, utilization: Double) {
+            self.isEnabled = isEnabled
+            self.monthlyLimit = monthlyLimit
+            self.usedCredits = usedCredits
+            self.utilization = utilization
+        }
     }
 
     // MARK: - Computed (gauge / notification compatibility)

--- a/docs/auto-reload-handoff.md
+++ b/docs/auto-reload-handoff.md
@@ -1,0 +1,267 @@
+# Auto-Reload Awareness — Implementation Handoff
+
+## Context
+
+The popover already shows two warning signals when budgets are tight:
+
+1. **Claude side** — `BudgetStripView` (in `AIQuota/Views/BudgetStripView.swift`) appears
+   inside the Claude column of the stats row when `extraUsage.utilization >= 70`,
+   escalating amber → red at 85%.
+2. **Codex side** — the `Credits: N` row in `claudeSecondaryStats` is tinted via
+   `creditTint(_:)` in `PopoverView.swift`: amber below `$20`, red below `$5`. (See
+   the open question on units below.)
+
+Both treatments assume the user will be cut off / charged unexpectedly and need to
+take action. **That assumption is wrong when auto-reload is on.** A user who has
+opted into auto-reload is fine with the system topping them up — hitting zero is
+just a routine refill, not a crisis. Showing them a screaming red "Credits: 0" is
+overstating the panic.
+
+This task: capture each service's auto-reload state and use it to *soften* the
+warning treatment when reload is on. Never alarm louder than the underlying
+situation warrants.
+
+---
+
+## Endpoints (verified via DevTools, May 2026)
+
+### Codex (ChatGPT / OpenAI)
+
+**Read:** `GET https://chatgpt.com/backend-api/wham/auto_top_up/settings`
+*(real path: `/backend-api/subscriptions/auto_top_up/settings`, exposed under the
+chatgpt.com host through the same Bearer-token auth mechanism the existing
+`OpenAIClient.fetchUsage()` uses.)*
+
+**Response shape:**
+
+```json
+{
+  "is_enabled": true,
+  "recharge_threshold": "125",
+  "recharge_target": "250",
+  "recharge_monthly_limit": null,
+  "immediate_top_up_status": null,
+  "immediate_top_up_message": null
+}
+```
+
+Field semantics:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `is_enabled` | `Bool` | Master toggle. `true` = auto-reload active. |
+| `recharge_threshold` | **`String`** (parses to numeric credits) | The minimum balance that triggers a refill. |
+| `recharge_target` | **`String`** (parses to numeric credits) | Refill brings balance up to this number. |
+| `recharge_monthly_limit` | `Int?` | Monthly cap on auto-reload spend; usually `null`. |
+| `immediate_top_up_status` | `String?` | Set during an in-flight reload; usually `null`. |
+| `immediate_top_up_message` | `String?` | Companion message for `immediate_top_up_status`. |
+
+**Trap:** `recharge_threshold` and `recharge_target` come back as JSON strings, not
+numbers. Parse them to `Double` (or `Int`) on decode.
+
+**Write:** `POST /backend-api/subscriptions/auto_top_up/update` — body
+`{"recharge_threshold": "125", "recharge_target": "250"}`. Not needed for this
+task (read-only).
+
+### Claude (Anthropic)
+
+**Already captured in our existing model.** We don't need a new endpoint —
+`ClaudeUsage.ExtraUsage.isEnabled` already carries the signal.
+
+For reference, the underlying API:
+
+**Read:** `GET https://claude.ai/api/organizations/{org_uuid}/overage_spend_limit`
+
+**Response shape (truncated to relevant fields):**
+
+```json
+{
+  "is_enabled": true,
+  "monthly_credit_limit": 8000,
+  "currency": "USD",
+  "used_credits": 5225,
+  "out_of_credits": false,
+  "disabled_reason": null,
+  "disabled_until": null
+}
+```
+
+`is_enabled` here is the same toggle that the `/usage` endpoint surfaces in
+`extra_usage.is_enabled`. **Don't add a new fetch for Claude** — keep using what's
+already there.
+
+(Bonus fields surfaced by this endpoint that may be useful for future polish:
+`out_of_credits` for explicit cut-off detection, `disabled_reason`/`disabled_until`
+for cases where Anthropic temporarily disables overage on an account. Not in scope
+here.)
+
+---
+
+## Conceptual model: how auto-reload differs between services
+
+Codex and Claude have *different* "extra usage" architectures, and the warning
+softening must respect those differences:
+
+- **Codex:** prepaid credit balance + auto-reload threshold/target. Auto-reload
+  refills the balance when it drops below the threshold. Hitting zero just means
+  "a refill is incoming." When `is_enabled = true`, the user will essentially
+  never be cut off — they're authorizing automatic top-ups indefinitely.
+
+- **Claude:** monthly spend cap (`monthly_credit_limit`) + auto-charge toggle
+  (`is_enabled`). Auto-reload here means *"automatically charge me for overage
+  up to the cap."* It does **not** refill the cap mid-month. Once
+  `used_credits >= monthly_credit_limit`, the user **is** cut off until the
+  monthly reset, regardless of `is_enabled`. So the existing strip behavior
+  (red at 85%+) is correct and should not be softened.
+
+This means: **only the Codex side gets softened by `is_enabled`.** Claude's
+existing strip stays as-is.
+
+---
+
+## Implementation plan
+
+### 1. New model: `CodexAutoReload`
+
+Add to `Packages/AIQuotaKit/Sources/AIQuotaKit/Models/CodexUsage.swift`
+(or a dedicated `CodexAutoReload.swift` next to it):
+
+```swift
+public struct CodexAutoReload: Codable, Sendable, Equatable {
+    public let isEnabled: Bool
+    public let rechargeThreshold: Double  // parsed from String
+    public let rechargeTarget: Double     // parsed from String
+
+    public init(isEnabled: Bool, rechargeThreshold: Double, rechargeTarget: Double) {
+        self.isEnabled = isEnabled
+        self.rechargeThreshold = rechargeThreshold
+        self.rechargeTarget = rechargeTarget
+    }
+}
+```
+
+Companion raw-decode struct (`AutoTopUpSettingsResponse`) to handle the
+String→Double parsing — mirror the pattern used by `WhamUsageResponse` in
+`CodexUsage.swift`.
+
+### 2. Network call: `OpenAIClient.fetchAutoReload()`
+
+In `Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/OpenAIClient.swift`,
+add a method that mirrors the existing `fetchUsage()`:
+
+- Same Bearer-token auth (use `coordinator` the same way)
+- Hit `/backend-api/subscriptions/auto_top_up/settings`
+- Decode `AutoTopUpSettingsResponse`
+- Return `CodexAutoReload`
+- Use the same `Logger` instance you'll find from the recent OSLog migration
+  (subsystem `app.aiquota`, category `OpenAIClient`)
+- Same error-throwing conventions (`NetworkError.decodingError`, etc.)
+
+### 3. View model: fetch alongside usage
+
+In `AIQuota/ViewModels/QuotaViewModel.swift`:
+
+- Add `var codexAutoReload: CodexAutoReload?` as observable state
+- In the existing Codex refresh path (around the `fetchUsage()` call site),
+  fire `fetchAutoReload()` *concurrently* (use `async let`) so we don't double
+  the latency. Apply the same suppression rules as the usage decode path
+  (the recent fix that conditions suppression on existing data).
+- On error from auto-reload only (not usage), fail open — log and leave
+  `codexAutoReload` at its previous value. The credit warning treatment must
+  not regress just because the auxiliary endpoint hiccupped.
+
+### 4. PopoverView: soften the credit warning when reload is on
+
+Update `creditTint(_:)` in `AIQuota/Views/PopoverView.swift` (currently a
+free function on the view). Change its signature to accept the auto-reload
+state:
+
+```swift
+private func creditTint(_ balance: Double, autoReload: CodexAutoReload?) -> Color {
+    if autoReload?.isEnabled == true {
+        // Auto-reload covers the user — soft amber when actually below their
+        // own threshold (refill imminent), never red.
+        if balance <= autoReload!.rechargeThreshold { return .orange }
+        return .primary
+    }
+    // No auto-reload: existing absolute thresholds apply
+    if balance < 5 { return .red }
+    if balance < 20 { return .orange }
+    return .primary
+}
+```
+
+Update the call site in `codexSecondaryStats` to pass
+`viewModel.codexAutoReload`.
+
+### 5. PopoverView: add an "auto-reload" hint
+
+When `autoReload?.isEnabled == true`, append a tertiary-color hint after the
+credit number so users understand why the warning is muted. Suggested:
+
+```
+Credits: 73 · auto-reload
+```
+
+Specifically: extend the `compactRow` helper with an optional `suffix: String?`
+parameter rendered in `.tertiary` after the value, OR render a custom row for
+the credits case. Keep typography consistent with the rest of `compactRow`
+output (caption2). Don't make the hint visually loud.
+
+### 6. Open question: dollars vs credits
+
+The current hardcoded thresholds (`< $5` red, `< $20` amber) were dollar-thinking.
+We've since confirmed Codex credits are **abstract units, not dollars** — daily
+consumption commonly reaches 100–300 credits, and the user's auto-reload threshold
+is `125`. Once you have `rechargeThreshold` available, the auto-reload-on path
+above uses it natively (no calibration needed). For the auto-reload-off path,
+**leave the existing 5/20 thresholds alone in this PR** — they're admittedly
+arbitrary, but recalibration is out of scope here and worth a separate
+conversation about defaults. File a follow-up.
+
+### 7. Demo driver
+
+In `AIQuota/Demo/DemoDriver.swift`:
+
+- Currently has a `codexBalance: [Int: Double]` map indexed by frame. Add a
+  parallel `codexAutoReload: [Int: CodexAutoReload]` (or just toggle
+  `isEnabled` per frame) so the demo cycles through both states. Suggested
+  pattern: first half of the timeline shows auto-reload off (existing red/amber
+  behavior), second half toggles it on (warning softens to amber + hint). This
+  lets the demo loop showcase both paths.
+- Wire the new value through `applyDemoFrame` in `QuotaViewModel`, mirroring how
+  `claude` and `codex` are passed today.
+
+---
+
+## Acceptance criteria
+
+The PR should:
+
+- [ ] Build cleanly with `xcodebuild -scheme AIQuota` and `xcodebuild -scheme AIQuota-Demo -configuration Demo`
+- [ ] When auto-reload is **off** and balance is low, show red/amber as before (no regression)
+- [ ] When auto-reload is **on**, never show red on the credits row — cap at amber below the user's `recharge_threshold`, primary color above it
+- [ ] When auto-reload is **on**, show a `· auto-reload` tertiary hint after the credit number
+- [ ] If the auto-reload endpoint fails or hasn't loaded yet, treat as `nil` and fall back to absolute-threshold behavior (no crash, no missing tint)
+- [ ] Demo cycle exercises both auto-reload states so both code paths are visible without needing real API calls
+- [ ] No changes to Claude's strip behavior (the existing logic is correct)
+
+## Open the PR with a clear summary
+
+Final commit + PR should describe:
+1. The asymmetry between Codex and Claude auto-reload semantics (so future readers don't try to "fix" the asymmetry)
+2. Why the absolute `<$5` / `<$20` thresholds are kept in the auto-reload-off path despite credits not being dollars (out of scope, follow-up)
+3. The fail-open behavior on auto-reload fetch errors
+
+## Branch context
+
+You're branching off `claude/naughty-dewdney-23fc4a`, which already contains:
+
+- `BudgetStripView` for Claude extra usage (`AIQuota/Views/BudgetStripView.swift`)
+- The `creditTint` helper for Codex credits (in `PopoverView.swift`)
+- Demo driver scaffolding for both signals (`DemoDriver.swift`)
+- A public `init` on `ClaudeUsage.ExtraUsage` (`Packages/AIQuotaKit/.../ClaudeUsage.swift`)
+
+The networking polish that this branch builds on (recently merged on `main`):
+`OpenAIClient` and `ClaudeClient` now use `OSLog.Logger` — use that pattern, not
+`print()`, in any new logging you add.


### PR DESCRIPTION
## Summary

Adds two warning treatments to the popover bottom row, plus a self-contained handoff doc for the auto-reload follow-up that this branch sets up but does not implement.

- **Budget strip (Claude)** — new `BudgetStripView` rendered inside the Claude column of the stats row when `extraUsage.utilization >= 70`, escalating amber → red at 85%. Lives within the 50/50 column split (no T-intersections, no orphan dividers, no floating Codex column). Replaces the old `Extra: 1640/2000` compact row when active.
- **Low-balance tint (Codex)** — `Credits: N` value goes amber below `$20` and red below `$5` via a new `creditTint(_:)` helper. Mirrors the strip's escalation language without faking a quota (Codex API doesn't expose a denominator).
- **Public init on `ClaudeUsage.ExtraUsage`** — required so previews and demo-driver fixtures can construct values from outside the package.
- **Demo driver upgrade** — `claudeExtraUsage` and `codexBalance` maps cycle the warning states (off → amber → red) over the timeline so both signals are exercised in `Demo` builds. Tick durations also retuned to ~14s total run with ±25% jitter so the demo loops through all states promptly.
- **`docs/auto-reload-handoff.md`** — full spec for the auto-reload awareness work (verified endpoints, conceptual model, file-level implementation plan, acceptance criteria). Set up so a follow-up contributor — including a remote agent — can pick it up cold.

## Why this design

- The strip is restricted to the Claude column to preserve the existing 50/50 split and make attribution unambiguous (the urgency belongs to Claude, not Codex).
- The strip lives *inside* `claudeSecondaryStats` rather than as a standalone row above the stats — that puts it under the same single full-width divider as the stats, eliminating the T-intersection / orphan-rule problem an earlier iteration created.
- The Codex side gets a tint, not a bar, because the underlying API genuinely doesn't return a denominator (just a flat balance). Faking one would mislead.

## Out of scope (handoff doc covers)

- **Auto-reload awareness** — when a user has auto-reload on, both warning treatments should soften (cap at amber, never red, and append a `· auto-reload` hint). The endpoints are documented in `docs/auto-reload-handoff.md`; implementation is a follow-up.
- **Credit-unit calibration** — Codex `creditBalance` is in abstract credit units, not dollars (daily burn commonly runs 100–300 credits). The `<$5` / `<$20` thresholds are admittedly arbitrary as absolute credit numbers; recalibration is also out of scope here and worth a separate conversation about defaults.

## Test plan

- [ ] Build `AIQuota` and `AIQuota-Demo` schemes — both clean
- [ ] Run the `AIQuota-Demo` scheme; observe over a single ~14s cycle:
  - [ ] Strip is hidden while Claude utilization is below 70%
  - [ ] Strip appears in amber once utilization crosses 70%
  - [ ] Strip turns red once utilization crosses 85%
  - [ ] Codex credits row stays default color while balance ≥ $20
  - [ ] Codex credits row turns amber below $20
  - [ ] Codex credits row turns red below $5
  - [ ] No double dividers, no orphan rules, no floating Codex column at any frame
- [ ] When the strip is visible, the redundant `Extra: X/Y` compact row is suppressed (no duplication)
- [ ] When the strip is hidden (utilization < 70%), `Extra: X/Y` renders in the stats column as before