### PR TITLE
feat: Codex auto-reload-aware warnings and credit top-up notifications

### DIFF
--- a/AIQuota/Demo/DemoDriver.swift
+++ b/AIQuota/Demo/DemoDriver.swift
@@ -131,8 +131,9 @@ final class DemoDriver {
 
     // MARK: - Codex balance progression
     //
-    // Drains gradually so the demo also showcases the credits row's
-    // amber (< $20) and red (< $5) treatment alongside the Claude strip.
+    // First half: auto-reload off — drains into red so the absolute-threshold
+    // tint is visible. Second half: auto-reload on — balance jumps on reload,
+    // stays softened to amber below the threshold, never red.
 
     private let codexBalance: [Int: Double] = {
         var map: [Int: Double] = [:]
@@ -140,15 +141,32 @@ final class DemoDriver {
         for i in 0...16   { map[i] = 197.18 - Double(i) * 4 }   // 197 → 133
         // Cycle 3: still normal but visibly dropping
         for i in 17...20  { map[i] = 90 - Double(i - 17) * 18 } // 90 → 36
-        // Final approach: amber territory
+        // Final approach (auto-reload off): amber territory
         map[21] = 18
         map[22] = 11
-        // Last frames: red
+        // Frames 23–24: red territory (auto-reload still off)
         map[23] = 6
         map[24] = 3
-        map[25] = 1
-        map[26] = 0
-        map[27] = 0
+        // Frame 25: auto-reload kicks in — balance jumps from 3 → 250.
+        // This triggers the top-up notification (delta = 247 >> noise floor 50).
+        map[25] = 250
+        // Frames 26–27: healthy balance, auto-reload on, warning softened
+        map[26] = 200
+        map[27] = 185
+        return map
+    }()
+
+    // MARK: - Codex auto-reload progression
+    //
+    // Frames 0–24: auto-reload off — absolute red/amber thresholds apply (showcases
+    // the urgency treatment users see before opting into auto-reload).
+    // Frames 25–27: auto-reload on — warning softens, · auto-reload hint appears,
+    // and the balance jump at frame 25 fires the top-up notification.
+
+    private let codexAutoReloadFrames: [Int: CodexAutoReload] = {
+        var map: [Int: CodexAutoReload] = [:]
+        let on = CodexAutoReload(isEnabled: true, rechargeThreshold: 125, rechargeTarget: 250)
+        for i in 25...27 { map[i] = on }
         return map
     }()
 
@@ -255,6 +273,8 @@ final class DemoDriver {
         codexIndex += 1
 
         let now = Date.now
+        let autoReload = codexAutoReloadFrames[codexIndex - 1]
+        let balance    = codexBalance[codexIndex - 1] ?? 197.18
         let codex = CodexUsage(
             weeklyUsedPercent:       Int(f.sevenD.rounded()),
             weeklyResetAt:           now.addingTimeInterval(TimeInterval(f.weeklyResetDays * 86400)),
@@ -266,7 +286,7 @@ final class DemoDriver {
             limitReached:            f.fiveH >= 100,
             allowed:                 f.fiveH < 100,
             planType:                "plus",
-            creditBalance:           codexBalance[codexIndex - 1] ?? 197.18,
+            creditBalance:           balance,
             approxLocalMessages:     nil,
             approxCloudMessages:     nil,
             fetchedAt:               now
@@ -274,7 +294,17 @@ final class DemoDriver {
 
         target.applyDemoFrame(claude: target.claudeUsage, codex: codex,
                               claudeLoading: target.isClaudeLoading,
-                              codexLoading: false)
+                              codexLoading: false,
+                              codexAutoReload: autoReload)
+
+        // Mirror production: evaluate top-up notification for each simulated refresh
+        Task {
+            await NotificationManager.shared.evaluateTopUp(
+                currentBalance: balance,
+                autoReload: autoReload,
+                prefs: target.settings.notifications
+            )
+        }
 
         if codexIndex < codexFrames.count {
             scheduleNextCodex()

--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -15,6 +15,7 @@ final class QuotaViewModel {
     // MARK: - Codex (OpenAI)
 
     var codexUsage: CodexUsage?
+    var codexAutoReload: CodexAutoReload?
     var isCodexLoading = false
     var codexError: NetworkError?
 
@@ -143,8 +144,9 @@ final class QuotaViewModel {
         }
 
         // Step 3: product state reset (only after auth reset completes)
-        claudeUsage = nil
-        codexUsage  = nil
+        claudeUsage     = nil
+        codexUsage      = nil
+        codexAutoReload = nil
         SharedDefaults.clearUsage()
         SharedDefaults.clearClaudeUsage()
         settings = .default
@@ -253,7 +255,8 @@ final class QuotaViewModel {
                         self.startAutoRefresh()
                     }
                     if state == .unauthenticated || state == .signedOutByUser {
-                        self.codexUsage = nil
+                        self.codexUsage      = nil
+                        self.codexAutoReload = nil
                         SharedDefaults.clearUsage()
                         WidgetCenter.shared.reloadAllTimelines()
                     }
@@ -423,11 +426,30 @@ final class QuotaViewModel {
         defer { if codexRefreshGeneration == gen { isCodexLoading = false } }
 
         do {
-            let result = try await codexClient.fetchUsage()
+            async let usageResult      = codexClient.fetchUsage()
+            async let autoReloadResult = codexClient.fetchAutoReload()
+
+            let result = try await usageResult
+
+            // Auto-reload fetch: fail-open — errors leave codexAutoReload at its previous value
+            // so the credit-warning treatment never regresses due to an auxiliary endpoint hiccup.
+            if let reloadData = try? await autoReloadResult {
+                codexAutoReload = reloadData
+            } else {
+                logger.info("[CodexRefresh] auto-reload fetch failed — leaving codexAutoReload unchanged")
+            }
+
             codexUsage = result
             lastRefreshedAt = .now
             SharedDefaults.saveUsage(result)
             await NotificationManager.shared.evaluate(current: result, prefs: settings.notifications)
+            if let balance = result.creditBalance {
+                await NotificationManager.shared.evaluateTopUp(
+                    currentBalance: balance,
+                    autoReload: codexAutoReload,
+                    prefs: settings.notifications
+                )
+            }
         } catch let e as NetworkError {
             if e.isAuthError {
                 codexUsage = nil
@@ -442,6 +464,13 @@ final class QuotaViewModel {
                     lastRefreshedAt = .now
                     SharedDefaults.saveUsage(result)
                     await NotificationManager.shared.evaluate(current: result, prefs: settings.notifications)
+                    if let balance = result.creditBalance {
+                        await NotificationManager.shared.evaluateTopUp(
+                            currentBalance: balance,
+                            autoReload: codexAutoReload,
+                            prefs: settings.notifications
+                        )
+                    }
                 } catch {
                     // Retry also failed — coordinator already transitioned to unauthenticated
                 }
@@ -792,13 +821,15 @@ extension QuotaViewModel {
         claude: ClaudeUsage?,
         codex: CodexUsage?,
         claudeLoading: Bool = false,
-        codexLoading: Bool = false
+        codexLoading: Bool = false,
+        codexAutoReload: CodexAutoReload? = nil
     ) {
-        claudeUsage     = claude
-        codexUsage      = codex
-        isClaudeLoading = claudeLoading
-        isCodexLoading  = codexLoading
-        lastRefreshedAt = claude != nil || codex != nil ? .now : nil
+        claudeUsage         = claude
+        codexUsage          = codex
+        isClaudeLoading     = claudeLoading
+        isCodexLoading      = codexLoading
+        lastRefreshedAt     = claude != nil || codex != nil ? .now : nil
+        self.codexAutoReload = codexAutoReload
     }
 }
 #endif

--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -279,18 +279,33 @@ struct PopoverView: View {
     @ViewBuilder
     private var codexSecondaryStats: some View {
         if let usage = viewModel.codexUsage {
+            let autoReload = viewModel.codexAutoReload
             VStack(alignment: .leading, spacing: 5) {
                 if let balance = usage.creditBalance {
-                    compactRow("Credits", "\(Int(balance))", valueTint: creditTint(balance))
+                    compactRow(
+                        "Credits", "\(Int(balance))",
+                        valueTint: creditTint(balance, autoReload: autoReload),
+                        suffix: autoReload?.isEnabled == true ? "· auto-reload" : nil
+                    )
                 }
                 compactRow("Plan", usage.planType.capitalized)
             }
         }
     }
 
-    /// Mirrors the Claude strip's escalation in a balance-based world:
-    /// red below $5 (critical), amber below $20 (running low), normal otherwise.
-    private func creditTint(_ balance: Double) -> Color {
+    /// Returns a tint color for the credits balance row.
+    ///
+    /// Auto-reload on: cap at amber when below the user's own recharge threshold
+    /// (a refill is imminent), never red. Primary above the threshold.
+    ///
+    /// Auto-reload off: existing absolute thresholds — red below 5, amber below 20.
+    /// These thresholds were calibrated for dollar amounts and are acknowledged as
+    /// imprecise for credit units; recalibration is deferred to a follow-up.
+    private func creditTint(_ balance: Double, autoReload: CodexAutoReload?) -> Color {
+        if autoReload?.isEnabled == true {
+            if balance <= autoReload!.rechargeThreshold { return .orange }
+            return .primary
+        }
         if balance < 5 { return .red }
         if balance < 20 { return .orange }
         return .primary
@@ -312,11 +327,14 @@ struct PopoverView: View {
         }
     }
 
-    private func compactRow(_ label: String, _ value: String, valueTint: Color = .primary) -> some View {
+    private func compactRow(_ label: String, _ value: String, valueTint: Color = .primary, suffix: String? = nil) -> some View {
         HStack(spacing: 5) {
             Text(label + ":").font(.caption2).foregroundStyle(.secondary)
             Text(value).font(.caption2.monospacedDigit().bold())
                 .foregroundStyle(valueTint)
+            if let suffix {
+                Text(suffix).font(.caption2).foregroundStyle(.tertiary)
+            }
         }
     }
 

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -113,6 +113,9 @@ struct SettingsView: View {
                         notifSubHeader("7-day window")
                         Toggle("Usage alerts", isOn: $vm.settings.notifications.codexWeeklyThresholdAlerts)
                         Toggle("Reset alert",  isOn: $vm.settings.notifications.codexReset)
+
+                        notifSubHeader("Credits")
+                        Toggle("Top-up events", isOn: $vm.settings.notifications.codexTopUp)
                     }
                 }
                 .disabled(!notifSectionsEnabled)

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift
@@ -56,6 +56,9 @@ public struct NotificationPreferences: Codable, Sendable, Equatable {
     public var claude7dLimitReached: Bool = true
     public var claude7dReset: Bool = true
 
+    // Codex — credit top-up events
+    public var codexTopUp: Bool = true          // balance jump > 50 credits
+
     public init() {}
 
     /// Migration-safe decoder: missing keys fall back to defaults rather than throwing.
@@ -80,6 +83,7 @@ public struct NotificationPreferences: Codable, Sendable, Equatable {
         claude7dAt95         = try c.decodeIfPresent(Bool.self, forKey: .claude7dAt95)         ?? true
         claude7dLimitReached = try c.decodeIfPresent(Bool.self, forKey: .claude7dLimitReached) ?? true
         claude7dReset        = try c.decodeIfPresent(Bool.self, forKey: .claude7dReset)        ?? true
+        codexTopUp           = try c.decodeIfPresent(Bool.self, forKey: .codexTopUp)           ?? true
     }
 
     // MARK: - Aggregate computed properties (UI consolidation)

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/CodexUsage.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/CodexUsage.swift
@@ -153,3 +153,30 @@ public struct CodexUsage: Codable, Sendable, Equatable {
         self.fetchedAt = fetchedAt
     }
 }
+
+// MARK: - Auto-reload settings
+
+/// Codex auto-reload state fetched from `/backend-api/subscriptions/auto_top_up/settings`.
+/// When `isEnabled` is true, the balance refills automatically when it drops below
+/// `rechargeThreshold` — hitting zero is routine, not a crisis.
+public struct CodexAutoReload: Codable, Sendable, Equatable {
+    public let isEnabled: Bool
+    /// Balance level that triggers a refill (parsed from the JSON String field).
+    public let rechargeThreshold: Double
+    /// Balance target after a refill (parsed from the JSON String field).
+    public let rechargeTarget: Double
+
+    public init(isEnabled: Bool, rechargeThreshold: Double, rechargeTarget: Double) {
+        self.isEnabled = isEnabled
+        self.rechargeThreshold = rechargeThreshold
+        self.rechargeTarget = rechargeTarget
+    }
+}
+
+// Internal decode type — the API returns `rechargeThreshold` and `rechargeTarget` as
+// JSON strings rather than numbers, so we can't decode directly into Double.
+struct AutoTopUpSettingsResponse: Decodable, Sendable {
+    let isEnabled: Bool
+    let rechargeThreshold: String
+    let rechargeTarget: String
+}

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/OpenAIClient.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/OpenAIClient.swift
@@ -9,6 +9,7 @@ public actor OpenAIClient {
     private let baseURL = URL(string: "https://chatgpt.com")!
     // Confirmed endpoint from network inspection of chatgpt.com/codex/settings/usage
     private let usagePath = "/backend-api/wham/usage"
+    private let autoTopUpPath = "/backend-api/subscriptions/auto_top_up/settings"
 
     public init(coordinator: CodexAuthCoordinator) {
         self.coordinator = coordinator
@@ -57,4 +58,56 @@ public actor OpenAIClient {
             throw NetworkError.decodingError(underlying: error)
         }
     }
+
+    public func fetchAutoReload() async throws -> CodexAutoReload {
+        let token = try await coordinator.accessToken()
+
+        var req = URLRequest(url: baseURL.appendingPathComponent(autoTopUpPath))
+        req.httpMethod = "GET"
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue("https://chatgpt.com/codex/settings/usage", forHTTPHeaderField: "Referer")
+        req.setValue("same-origin", forHTTPHeaderField: "Sec-Fetch-Site")
+        req.setValue("cors", forHTTPHeaderField: "Sec-Fetch-Mode")
+        req.setValue("en-US,en;q=0.9", forHTTPHeaderField: "Accept-Language")
+
+        let (data, response) = try await session.data(for: req)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw NetworkError.networkUnavailable
+        }
+
+        switch http.statusCode {
+        case 200...299:
+            break
+        case 401:
+            throw NetworkError.tokenExpired
+        case 429:
+            throw NetworkError.rateLimited
+        default:
+            throw NetworkError.httpError(statusCode: http.statusCode)
+        }
+
+        let raw: AutoTopUpSettingsResponse
+        do {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            raw = try decoder.decode(AutoTopUpSettingsResponse.self, from: data)
+        } catch {
+            let preview = String(data: data.prefix(2000), encoding: .utf8) ?? "<non-UTF8>"
+            logger.error("[OpenAIClient] fetchAutoReload decodingError: \(error) | body: \(preview)")
+            throw NetworkError.decodingError(underlying: error)
+        }
+
+        guard let threshold = Double(raw.rechargeThreshold),
+              let target    = Double(raw.rechargeTarget) else {
+            logger.error("[OpenAIClient] fetchAutoReload: unparseable strings threshold=\(raw.rechargeThreshold) target=\(raw.rechargeTarget)")
+            throw NetworkError.decodingError(underlying: AutoReloadParseError.stringToDouble)
+        }
+        return CodexAutoReload(isEnabled: raw.isEnabled, rechargeThreshold: threshold, rechargeTarget: target)
+    }
+}
+
+private enum AutoReloadParseError: Error {
+    case stringToDouble
 }

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Notifications/NotificationManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Notifications/NotificationManager.swift
@@ -18,6 +18,8 @@ public actor NotificationManager {
         // Codex — weekly window
         static let codexThresholds  = "notificationThresholds"
         static let codexLastResetAt = "notificationLastResetAt"
+        // Codex — credit top-up diffing
+        static let codexLastBalance = "codexLastBalance"
         // Claude 5h window
         static let claudeThresholds  = "claudeNotificationThresholds"
         static let claudeLastResetAt = "claudeNotificationLastResetAt"
@@ -138,6 +140,44 @@ public actor NotificationManager {
                 body: "You've used most of your Codex 7-day window. Resets in \(timeString(current.weeklyResetAfterSeconds))."
             )
         }
+    }
+
+    // MARK: - Codex top-up detection
+
+    /// Noise floor for top-up detection. Daily consumption commonly reaches
+    /// 100–300 credits; real refills are typically ≥ 125 (recharge_target − recharge_threshold).
+    /// 50 is well above normal variance without missing genuine top-ups.
+    private let topUpNoiseFloor: Double = 50
+
+    /// Called after every successful Codex usage fetch. Compares the current balance
+    /// against the previously stored value; fires a notification when a top-up is
+    /// detected (balance increased by more than the noise floor).
+    ///
+    /// Always updates the stored balance regardless of whether a notification fires —
+    /// including on first launch (where it stores and returns without firing).
+    public func evaluateTopUp(currentBalance: Double, autoReload: CodexAutoReload?, prefs: NotificationPreferences) async {
+        let lastBalance = defaults.object(forKey: Key.codexLastBalance) as? Double
+        defaults.set(currentBalance, forKey: Key.codexLastBalance)
+
+        guard let lastBalance else { return }  // first launch — stored, don't fire
+        guard currentBalance > lastBalance + topUpNoiseFloor else { return }
+
+        // Real top-up detected; fire if permitted
+        guard prefs.enabled, prefs.codexTopUp else { return }
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus == .authorized else { return }
+
+        let title: String
+        let body: String
+        if autoReload?.isEnabled == true {
+            title = "Codex credits topped up"
+            body  = "Auto-reload added credits. New balance: \(Int(currentBalance))."
+        } else {
+            title = "Codex credits added"
+            body  = "New balance: \(Int(currentBalance))."
+        }
+        await send(id: "codexTopUp", title: title, body: body)
     }
 
     // MARK: - Claude evaluation

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
@@ -40,9 +40,11 @@ struct PopoverTypographyTests {
     func secondaryStatRowsOmitIcons() throws {
         let popoverSource = try String(contentsOf: repoRoot.appending(path: "AIQuota/Views/PopoverView.swift"), encoding: .utf8)
 
-        #expect(popoverSource.contains(#"compactRow("Credits", "\(Int(balance))")"#))
+        // Credits row uses compactRow helper (not a custom icon row)
+        #expect(popoverSource.contains(#""Credits", "\(Int(balance))""#))
         #expect(popoverSource.contains(#"compactRow("Extra", "\(Int(extra.usedCredits))/\(extra.monthlyLimit)")"#))
-        #expect(popoverSource.contains(#"private func compactRow(_ label: String, _ value: String) -> some View"#))
+        // compactRow signature now supports optional suffix for the · auto-reload hint
+        #expect(popoverSource.contains(#"private func compactRow(_ label: String, _ value: String, valueTint: Color = .primary, suffix: String? = nil) -> some View"#))
         #expect(!popoverSource.contains(#"Image(systemName: icon)"#))
         #expect(!popoverSource.contains(#"compactRow("Credits", "\(Int(balance))", "creditcard.fill")"#))
         #expect(!popoverSource.contains(#"compactRow("Extra", "\(Int(extra.usedCredits))/\(extra.monthlyLimit)", "plus.circle.fill")"#))


### PR DESCRIPTION
## Summary

- **Auto-reload-aware warning treatment** — fetches the Codex auto-reload setting concurrently with usage and softens the credits row color when reload is on, so the UI never screams red at a user whose balance is about to auto-refill
- **Codex top-up notifications** — diffs `creditBalance` across refreshes and fires a native macOS notification whenever the balance jumps by more than 50 credits (auto-reload or manual purchase), with a new opt-out toggle in Settings

## Why the asymmetry between Codex and Claude

Codex uses a **prepaid credit balance + threshold/target auto-reload**: when the balance drops below `rechargeThreshold`, it refills to `rechargeTarget`. Hitting zero is routine — a refill is always incoming. So `is_enabled = true` on Codex genuinely means "I'm covered indefinitely; don't alarm me."

Claude uses a **monthly spend cap + auto-charge toggle**: `is_enabled` means "charge me for overage up to the monthly limit," *not* "refill the cap mid-month." Once `used_credits >= monthly_credit_limit`, the user is cut off until the monthly reset regardless of `is_enabled`. The existing BudgetStripView (red at 85%+) is therefore correct and unchanged here. This asymmetry is intentional — future readers: don't try to "fix" it without re-reading the architecture.

## Auto-reload-aware warnings (part A)

- `GET /backend-api/subscriptions/auto_top_up/settings` is fetched via `OpenAIClient.fetchAutoReload()` concurrently with `fetchUsage()` using `async let`, so latency doesn't increase
- Fail-open: if the auto-reload endpoint errors, `codexAutoReload` stays at its last-known value (or nil). The absolute-threshold path is the fallback — credit warnings never regress due to an auxiliary endpoint hiccup
- `creditTint(_:autoReload:)` in PopoverView:
  - Auto-reload **on**: amber when `balance <= rechargeThreshold` (refill imminent), primary above it, never red
  - Auto-reload **off** (or nil): existing absolute thresholds — red below 5, amber below 20
- `· auto-reload` tertiary hint appended after the credit number via the new optional `suffix:` parameter on `compactRow()` when reload is on

**Note on the absolute `<5`/`<20` thresholds:** these were calibrated as dollar amounts and are now acknowledged as imprecise for Codex credit units (daily consumption commonly reaches 100–300 credits). Recalibration is out of scope for this PR — the auto-reload-on path above uses the user's own `rechargeThreshold` natively, which is correct. The off-path thresholds are left as-is pending a separate follow-up on unit calibration.

## Codex top-up notifications (part B)

Detection: after every successful Codex refresh, `NotificationManager.evaluateTopUp()` compares `currentBalance` against the persisted `lastCodexBalance`. The **noise floor is 50 credits** — daily consumption is in the 100–300 credit range, and real refills are typically `rechargeTarget − rechargeThreshold` (often ≥ 125), so 50 is comfortably above variance without missing real top-ups.

Always writes `lastCodexBalance = currentBalance` before checking the noise floor, including when prefs are off or there's no prior value. On first launch (nil stored value): stores and returns without firing.

Notification copy is auto-reload-aware:
- `codexAutoReload?.isEnabled == true` → "Codex credits topped up" / "Auto-reload added credits. New balance: N."
- Otherwise → "Codex credits added" / "New balance: N."

New **"Top-up events"** toggle in Settings > Codex > Credits section. Default ON (top-ups are positive, low-frequency, low-spam). Persisted as `NotificationPreferences.codexTopUp` with migration-safe `decodeIfPresent` default.

**Why Codex-only:** Claude's auto-reload doesn't refill a balance — it extends a monthly spend cap. There's no equivalent "balance jumped" event to notify on. If the Claude "Current balance" pool (visible in the UI but not in the endpoint we've reverse-engineered) is ever captured, we can revisit.

## Demo coverage

DemoDriver cycles through both states:
- Frames 0–24: auto-reload off → absolute red/amber treatment visible, balance drains to 3
- Frame 25: balance jumps 3 → 250 (delta 247 >> noise floor 50) + auto-reload on fires → top-up notification path fires, · auto-reload hint appears, warning softens to amber
- Frames 26–27: healthy balance with auto-reload on

## Test plan

- [ ] **Auto-reload off, balance below 5:** credits row shows red (no regression)
- [ ] **Auto-reload off, balance 5–20:** credits row shows amber
- [ ] **Auto-reload off, balance above 20:** credits row shows primary
- [ ] **Auto-reload on, balance above rechargeThreshold (125):** credits row shows primary + `· auto-reload` hint
- [ ] **Auto-reload on, balance at/below rechargeThreshold:** credits row shows amber (never red) + hint
- [ ] **Auto-reload endpoint fails:** UI falls back to absolute-threshold behavior; no crash
- [ ] **Demo cycle:** auto-reload states visible without real API calls; balance jump at frame 25 fires notification once per loop (requires notification permission granted)
- [ ] **Top-up notification fires** when balance increases by > 50 credits (demo or real refresh)
- [ ] **Top-up notification suppressed** when "Top-up events" toggle is off
- [ ] **First-launch** (no stored balance): stores balance, does not fire
- [ ] **New "Top-up events" toggle** in Settings, under Codex > Credits, default ON
- [ ] `xcodebuild -scheme AIQuota -destination 'platform=macOS' build` clean
- [ ] `xcodebuild -scheme AIQuota-Demo -configuration Demo build` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01ReFvnNFDUskiLsg38BWtUo)_