### PR TITLE
feat: Codex auto-reload awareness + top-up notifications

### DIFF
--- a/AIQuota/Demo/DemoDriver.swift
+++ b/AIQuota/Demo/DemoDriver.swift
@@ -131,24 +131,43 @@ final class DemoDriver {
 
     // MARK: - Codex balance progression
     //
-    // Drains gradually so the demo also showcases the credits row's
-    // amber (< $20) and red (< $5) treatment alongside the Claude strip.
+    // First half (frames 0–8, auto-reload OFF): drain from healthy through amber and
+    // into red territory, ending at 8 credits. Shows the existing red/amber tint treatment.
+    //
+    // Frame 9 (transition): auto-reload turns ON and balance jumps to 250 — this is
+    // the frame that triggers the top-up notification path once per demo loop.
+    //
+    // Second half (frames 10–27, auto-reload ON): balance drains slowly. Falls below
+    // the 125-credit recharge threshold around frame 19, showing amber (but never red)
+    // because auto-reload is active.
 
     private let codexBalance: [Int: Double] = {
         var map: [Int: Double] = [:]
-        // Cycles 1–2: healthy balance, slowly drawing down
-        for i in 0...16   { map[i] = 197.18 - Double(i) * 4 }   // 197 → 133
-        // Cycle 3: still normal but visibly dropping
-        for i in 17...20  { map[i] = 90 - Double(i - 17) * 18 } // 90 → 36
-        // Final approach: amber territory
-        map[21] = 18
-        map[22] = 11
-        // Last frames: red
-        map[23] = 6
-        map[24] = 3
-        map[25] = 1
-        map[26] = 0
-        map[27] = 0
+        // Frames 0–8: linear drain 197 → 8 (auto-reload OFF)
+        for i in 0...8 {
+            let frac = Double(i) / 8
+            map[i] = (197.18 * (1 - frac) + 8 * frac).rounded()
+        }
+        // Frame 9: auto-reload fires — balance jumps to 250
+        map[9] = 250
+        // Frames 10–27: drain 250 → 40 (auto-reload ON; amber below 125 around frame 19)
+        for i in 10...27 {
+            let frac = Double(i - 10) / 17
+            map[i] = max(40, (250 * (1 - frac) + 40 * frac).rounded())
+        }
+        return map
+    }()
+
+    // MARK: - Codex auto-reload progression
+    //
+    // Frames 0–8: no auto-reload — absolute thresholds apply (red < 5, amber < 20).
+    // Frame 9+: auto-reload ON (threshold 125, target 250) — warning softens; amber
+    // below threshold, primary above, never red.
+
+    private let codexAutoReloadFrames: [Int: CodexAutoReload] = {
+        var map: [Int: CodexAutoReload] = [:]
+        let reload = CodexAutoReload(isEnabled: true, rechargeThreshold: 125, rechargeTarget: 250)
+        for i in 9...27 { map[i] = reload }
         return map
     }()
 
@@ -272,9 +291,26 @@ final class DemoDriver {
             fetchedAt:               now
         )
 
-        target.applyDemoFrame(claude: target.claudeUsage, codex: codex,
-                              claudeLoading: target.isClaudeLoading,
-                              codexLoading: false)
+        let frameAutoReload = codexAutoReloadFrames[codexIndex - 1]
+        target.applyDemoFrame(
+            claude: target.claudeUsage, codex: codex,
+            claudeLoading: target.isClaudeLoading,
+            codexLoading: false,
+            codexAutoReload: frameAutoReload
+        )
+
+        // Mirror the production refresh path: evaluate top-up after each balance update
+        // so the demo fires a notification when the balance jumps at frame 9 (8 → 250).
+        let prefs = target.settings.notifications
+        if let balance = codex.creditBalance {
+            Task {
+                await NotificationManager.shared.evaluateCodexTopUp(
+                    currentBalance: balance,
+                    autoReload: frameAutoReload,
+                    prefs: prefs
+                )
+            }
+        }
 
         if codexIndex < codexFrames.count {
             scheduleNextCodex()

--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -15,6 +15,7 @@ final class QuotaViewModel {
     // MARK: - Codex (OpenAI)
 
     var codexUsage: CodexUsage?
+    var codexAutoReload: CodexAutoReload?
     var isCodexLoading = false
     var codexError: NetworkError?
 
@@ -423,11 +424,27 @@ final class QuotaViewModel {
         defer { if codexRefreshGeneration == gen { isCodexLoading = false } }
 
         do {
-            let result = try await codexClient.fetchUsage()
+            // Fire usage and auto-reload concurrently to avoid doubling latency.
+            // Auto-reload errors are suppressed and leave codexAutoReload at its previous
+            // value (fail open — a hiccup here must not regress credit-warning behavior).
+            async let usageFetch = codexClient.fetchUsage()
+            async let autoReloadFetch = silentAutoReloadFetch()
+
+            let result = try await usageFetch
+            let freshAutoReload = await autoReloadFetch
+            if let freshAutoReload { codexAutoReload = freshAutoReload }
+
             codexUsage = result
             lastRefreshedAt = .now
             SharedDefaults.saveUsage(result)
             await NotificationManager.shared.evaluate(current: result, prefs: settings.notifications)
+            if let balance = result.creditBalance {
+                await NotificationManager.shared.evaluateCodexTopUp(
+                    currentBalance: balance,
+                    autoReload: codexAutoReload,
+                    prefs: settings.notifications
+                )
+            }
         } catch let e as NetworkError {
             if e.isAuthError {
                 codexUsage = nil
@@ -442,6 +459,13 @@ final class QuotaViewModel {
                     lastRefreshedAt = .now
                     SharedDefaults.saveUsage(result)
                     await NotificationManager.shared.evaluate(current: result, prefs: settings.notifications)
+                    if let balance = result.creditBalance {
+                        await NotificationManager.shared.evaluateCodexTopUp(
+                            currentBalance: balance,
+                            autoReload: codexAutoReload,
+                            prefs: settings.notifications
+                        )
+                    }
                 } catch {
                     // Retry also failed — coordinator already transitioned to unauthenticated
                 }
@@ -476,6 +500,15 @@ final class QuotaViewModel {
             if isConnectivityError(error) || (pathMonitorReady && pathStatus != .satisfied) {
                 codexError = .networkUnavailable
             }
+        }
+    }
+
+    private func silentAutoReloadFetch() async -> CodexAutoReload? {
+        do {
+            return try await codexClient.fetchAutoReload()
+        } catch {
+            logger.info("[CodexRefresh] auto-reload fetch failed: \(error) — ignoring")
+            return nil
         }
     }
 
@@ -792,13 +825,15 @@ extension QuotaViewModel {
         claude: ClaudeUsage?,
         codex: CodexUsage?,
         claudeLoading: Bool = false,
-        codexLoading: Bool = false
+        codexLoading: Bool = false,
+        codexAutoReload newAutoReload: CodexAutoReload? = nil
     ) {
-        claudeUsage     = claude
-        codexUsage      = codex
-        isClaudeLoading = claudeLoading
-        isCodexLoading  = codexLoading
-        lastRefreshedAt = claude != nil || codex != nil ? .now : nil
+        claudeUsage        = claude
+        codexUsage         = codex
+        codexAutoReload    = newAutoReload
+        isClaudeLoading    = claudeLoading
+        isCodexLoading     = codexLoading
+        lastRefreshedAt    = claude != nil || codex != nil ? .now : nil
     }
 }
 #endif

--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -281,16 +281,27 @@ struct PopoverView: View {
         if let usage = viewModel.codexUsage {
             VStack(alignment: .leading, spacing: 5) {
                 if let balance = usage.creditBalance {
-                    compactRow("Credits", "\(Int(balance))", valueTint: creditTint(balance))
+                    let autoReload = viewModel.codexAutoReload
+                    compactRow(
+                        "Credits", "\(Int(balance))",
+                        valueTint: creditTint(balance, autoReload: autoReload),
+                        suffix: autoReload?.isEnabled == true ? "auto-reload" : nil
+                    )
                 }
                 compactRow("Plan", usage.planType.capitalized)
             }
         }
     }
 
-    /// Mirrors the Claude strip's escalation in a balance-based world:
-    /// red below $5 (critical), amber below $20 (running low), normal otherwise.
-    private func creditTint(_ balance: Double) -> Color {
+    /// Tints the credit balance. When auto-reload is on, the user will be refilled
+    /// automatically, so urgency is softened: amber only when below the user's own
+    /// recharge threshold, never red. When off, absolute thresholds apply.
+    /// (Note: the <$5/<$20 thresholds are admittedly arbitrary for credit units vs dollars —
+    /// recalibration is a separate follow-up; they are left unchanged for the reload-off path.)
+    private func creditTint(_ balance: Double, autoReload: CodexAutoReload?) -> Color {
+        if autoReload?.isEnabled == true {
+            return balance <= autoReload!.rechargeThreshold ? .orange : .primary
+        }
         if balance < 5 { return .red }
         if balance < 20 { return .orange }
         return .primary
@@ -312,11 +323,14 @@ struct PopoverView: View {
         }
     }
 
-    private func compactRow(_ label: String, _ value: String, valueTint: Color = .primary) -> some View {
+    private func compactRow(_ label: String, _ value: String, valueTint: Color = .primary, suffix: String? = nil) -> some View {
         HStack(spacing: 5) {
             Text(label + ":").font(.caption2).foregroundStyle(.secondary)
             Text(value).font(.caption2.monospacedDigit().bold())
                 .foregroundStyle(valueTint)
+            if let suffix {
+                Text("· \(suffix)").font(.caption2).foregroundStyle(.tertiary)
+            }
         }
     }
 

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -113,6 +113,9 @@ struct SettingsView: View {
                         notifSubHeader("7-day window")
                         Toggle("Usage alerts", isOn: $vm.settings.notifications.codexWeeklyThresholdAlerts)
                         Toggle("Reset alert",  isOn: $vm.settings.notifications.codexReset)
+
+                        notifSubHeader("Credits")
+                        Toggle("Top-up events", isOn: $vm.settings.notifications.codexTopUpEvents)
                     }
                 }
                 .disabled(!notifSectionsEnabled)

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AppSettings.swift
@@ -56,6 +56,9 @@ public struct NotificationPreferences: Codable, Sendable, Equatable {
     public var claude7dLimitReached: Bool = true
     public var claude7dReset: Bool = true
 
+    // Codex — credit top-up events (auto-reload or manual purchase)
+    public var codexTopUpEvents: Bool = true
+
     public init() {}
 
     /// Migration-safe decoder: missing keys fall back to defaults rather than throwing.
@@ -80,6 +83,7 @@ public struct NotificationPreferences: Codable, Sendable, Equatable {
         claude7dAt95         = try c.decodeIfPresent(Bool.self, forKey: .claude7dAt95)         ?? true
         claude7dLimitReached = try c.decodeIfPresent(Bool.self, forKey: .claude7dLimitReached) ?? true
         claude7dReset        = try c.decodeIfPresent(Bool.self, forKey: .claude7dReset)        ?? true
+        codexTopUpEvents     = try c.decodeIfPresent(Bool.self, forKey: .codexTopUpEvents)     ?? true
     }
 
     // MARK: - Aggregate computed properties (UI consolidation)

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/CodexUsage.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/CodexUsage.swift
@@ -1,5 +1,41 @@
 import Foundation
 
+// MARK: - Auto-reload settings
+
+/// Codex auto-reload (auto top-up) state fetched from the subscription settings endpoint.
+/// When `isEnabled` is true the user has opted into automatic credit refills, so hitting a
+/// low balance is a routine refill event rather than a crisis.
+public struct CodexAutoReload: Codable, Sendable, Equatable {
+    public let isEnabled: Bool
+    /// Balance level that triggers a refill (parsed from the JSON String field).
+    public let rechargeThreshold: Double
+    /// Balance the refill brings the account up to (parsed from the JSON String field).
+    public let rechargeTarget: Double
+
+    public init(isEnabled: Bool, rechargeThreshold: Double, rechargeTarget: Double) {
+        self.isEnabled = isEnabled
+        self.rechargeThreshold = rechargeThreshold
+        self.rechargeTarget = rechargeTarget
+    }
+}
+
+/// Raw response from `GET /backend-api/subscriptions/auto_top_up/settings`.
+/// `rechargeThreshold` and `rechargeTarget` arrive as JSON strings — convert to Double on decode.
+struct AutoTopUpSettingsResponse: Decodable, Sendable {
+    let isEnabled: Bool
+    let rechargeThreshold: String?
+    let rechargeTarget: String?
+
+    /// Returns nil if either numeric field is missing or unparseable.
+    func toCodexAutoReload() -> CodexAutoReload? {
+        guard
+            let thresholdStr = rechargeThreshold, let threshold = Double(thresholdStr),
+            let targetStr = rechargeTarget, let target = Double(targetStr)
+        else { return nil }
+        return CodexAutoReload(isEnabled: isEnabled, rechargeThreshold: threshold, rechargeTarget: target)
+    }
+}
+
 // MARK: - Raw API response from GET https://chatgpt.com/backend-api/wham/usage
 
 public struct WhamUsageResponse: Decodable, Sendable {

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/OpenAIClient.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/OpenAIClient.swift
@@ -9,6 +9,7 @@ public actor OpenAIClient {
     private let baseURL = URL(string: "https://chatgpt.com")!
     // Confirmed endpoint from network inspection of chatgpt.com/codex/settings/usage
     private let usagePath = "/backend-api/wham/usage"
+    private let autoReloadPath = "/backend-api/subscriptions/auto_top_up/settings"
 
     public init(coordinator: CodexAuthCoordinator) {
         self.coordinator = coordinator
@@ -56,5 +57,54 @@ public actor OpenAIClient {
             logger.error("[OpenAIClient] decodingError: \(error) | body: \(preview)")
             throw NetworkError.decodingError(underlying: error)
         }
+    }
+
+    public func fetchAutoReload() async throws -> CodexAutoReload {
+        let token = try await coordinator.accessToken()
+
+        var req = URLRequest(url: baseURL.appendingPathComponent(autoReloadPath))
+        req.httpMethod = "GET"
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue("application/json", forHTTPHeaderField: "Accept")
+        req.setValue("https://chatgpt.com/codex/settings/usage", forHTTPHeaderField: "Referer")
+        req.setValue("same-origin", forHTTPHeaderField: "Sec-Fetch-Site")
+        req.setValue("cors", forHTTPHeaderField: "Sec-Fetch-Mode")
+        req.setValue("en-US,en;q=0.9", forHTTPHeaderField: "Accept-Language")
+
+        let (data, response) = try await session.data(for: req)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw NetworkError.networkUnavailable
+        }
+
+        switch http.statusCode {
+        case 200...299:
+            break
+        case 401:
+            throw NetworkError.tokenExpired
+        case 429:
+            throw NetworkError.rateLimited
+        default:
+            throw NetworkError.httpError(statusCode: http.statusCode)
+        }
+
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let raw: AutoTopUpSettingsResponse
+        do {
+            raw = try decoder.decode(AutoTopUpSettingsResponse.self, from: data)
+        } catch {
+            let preview = String(data: data.prefix(2000), encoding: .utf8) ?? "<non-UTF8>"
+            logger.error("[OpenAIClient] autoReload decodingError: \(error) | body: \(preview)")
+            throw NetworkError.decodingError(underlying: error)
+        }
+        guard let result = raw.toCodexAutoReload() else {
+            let preview = String(data: data.prefix(200), encoding: .utf8) ?? "<non-UTF8>"
+            logger.error("[OpenAIClient] autoReload: numeric fields missing/non-parseable | body: \(preview)")
+            throw NetworkError.decodingError(underlying: DecodingError.dataCorrupted(
+                DecodingError.Context(codingPath: [], debugDescription: "rechargeThreshold/rechargeTarget missing or non-numeric")
+            ))
+        }
+        return result
     }
 }

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Notifications/NotificationManager.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Notifications/NotificationManager.swift
@@ -18,6 +18,8 @@ public actor NotificationManager {
         // Codex — weekly window
         static let codexThresholds  = "notificationThresholds"
         static let codexLastResetAt = "notificationLastResetAt"
+        // Codex — credit balance (for top-up diffing)
+        static let lastCodexBalance = "lastCodexBalance"
         // Claude 5h window
         static let claudeThresholds  = "claudeNotificationThresholds"
         static let claudeLastResetAt = "claudeNotificationLastResetAt"
@@ -25,6 +27,11 @@ public actor NotificationManager {
         static let claudeSevenDayThresholds  = "claudeSevenDayThresholds"
         static let claudeSevenDayLastResetAt = "claudeSevenDayLastResetAt"
     }
+
+    /// Minimum credit increase that qualifies as a top-up event.
+    /// Daily consumption is typically 100–300 credits; real refills are ≥ 125 credits
+    /// (recharge_target − recharge_threshold). 50 sits comfortably above session noise.
+    private let topUpNoiseFloor: Double = 50
 
     private var defaults: UserDefaults {
         UserDefaults(suiteName: "group.com.niederme.AIQuota") ?? .standard
@@ -251,6 +258,44 @@ public actor NotificationManager {
         } else {
             defaults.set(sevenDayResetAt, forKey: Key.claudeSevenDayLastResetAt)
         }
+    }
+
+    // MARK: - Codex top-up detection
+
+    /// Called after every successful Codex fetch. Persists the balance for diffing and,
+    /// when the balance has jumped by more than `topUpNoiseFloor`, fires a single
+    /// "credits topped up" notification.
+    ///
+    /// Always updates `lastCodexBalance` — even when no notification fires — so the
+    /// comparison stays fresh for future refreshes. On first launch (no stored value)
+    /// stores the balance without firing.
+    public func evaluateCodexTopUp(
+        currentBalance: Double,
+        autoReload: CodexAutoReload?,
+        prefs: NotificationPreferences
+    ) async {
+        let lastBalance = defaults.object(forKey: Key.lastCodexBalance) as? Double
+        defaults.set(currentBalance, forKey: Key.lastCodexBalance)
+
+        guard prefs.enabled, prefs.codexEnabled, prefs.codexTopUpEvents else { return }
+        guard let lastBalance else { return }  // first launch — stored above, no notification
+
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        guard settings.authorizationStatus == .authorized else { return }
+
+        guard currentBalance > lastBalance + topUpNoiseFloor else { return }
+
+        let title: String
+        let body: String
+        if autoReload?.isEnabled == true {
+            title = "Codex credits topped up"
+            body = "Auto-reload added credits. New balance: \(Int(currentBalance))."
+        } else {
+            title = "Codex credits added"
+            body = "New balance: \(Int(currentBalance))."
+        }
+        await send(id: "codexTopUp", title: title, body: body)
     }
 
     // MARK: - Private helpers


### PR DESCRIPTION
## Summary

Two related concerns, both motivated by the same insight: when a user has auto-reload active, hitting a low balance is a routine refill event, not a crisis — so the app shouldn't alarm them as if it were one.

**A. Auto-reload-aware warning treatment**
- New `CodexAutoReload` model parsed from `GET /backend-api/subscriptions/auto_top_up/settings` (the `recharge_threshold` and `recharge_target` fields arrive as JSON strings and are converted to `Double` on decode)
- `OpenAIClient.fetchAutoReload()` fires concurrently with `fetchUsage()` via `async let` — no added round-trip latency
- `codexAutoReload` state on `QuotaViewModel`; auto-reload fetch errors are silently suppressed (fail open) so a hiccup on the secondary endpoint never regresses the credit-warning path
- `creditTint(_:autoReload:)` in `PopoverView`: when `is_enabled = true`, caps at amber below the user's own `rechargeThreshold`, never red, primary above; `· auto-reload` tertiary hint appended to the credits row via a new `suffix` param on `compactRow`

**B. Codex top-up notifications**
- `NotificationManager.evaluateCodexTopUp()` diffs `creditBalance` against a persisted `lastCodexBalance` on every successful refresh; a jump of > 50 credits fires a notification
- Notification copy varies: "Codex credits topped up / Auto-reload added credits. New balance: N." when auto-reload is on, "Codex credits added / New balance: N." otherwise
- "Top-up events" toggle (default ON) added to Settings → Codex → Credits
- Demo cycle updated: frames 0–8 show auto-reload OFF (full red/amber range), frame 9 jumps balance from 8 → 250 (fires the notification), frames 10–27 show auto-reload ON (balance drains toward 40 with amber-only treatment below the 125-credit threshold)

## Architectural notes for future readers

**Why only Codex gets softened, not Claude:**
Codex auto-reload is prepaid-credit + threshold/target: it refills the balance when it drops below the threshold, so hitting zero is genuinely "a refill is incoming." Claude's `is_enabled` flag means "charge me for overage up to my monthly cap" — it does NOT refill the cap mid-month. Once `used_credits >= monthly_credit_limit`, the user IS cut off until the monthly reset regardless of `is_enabled`. The existing `BudgetStripView` red-at-85% behavior is correct and is untouched here.

**Why top-up notifications are Codex-only:**
Claude's auto-reload doesn't refill a balance pool — there's no equivalent "balance jumped" event to detect. Claude's separate "Current balance" pool (visible in the web UI) isn't surfaced by the endpoint we use. If we ever capture that, it's a separate conversation.

**Why the `<$5`/`<$20` thresholds are kept in the auto-reload-OFF path:**
They were dollar-thinking applied to credit units, and that's admittedly arbitrary. Recalibrating them requires a separate discussion about what the right defaults are (and possibly per-plan thresholds). Out of scope here — filed for follow-up.

**Fail-open on auto-reload fetch errors:**
`silentAutoReloadFetch()` catches all errors and returns `nil`, leaving `codexAutoReload` at its previous value. A nil `codexAutoReload` falls back to the existing absolute-threshold behavior, which is correct and safe.

**50-credit noise floor:**
Daily consumption is typically 100–300 credits; real refills are `recharge_target − recharge_threshold`, often ≥ 125 credits. 50 sits well above session-level noise without missing any real top-up. Named constant `topUpNoiseFloor` for future tuning.

## Test plan

- [ ] Auto-reload OFF path: credits row shows red below 5, amber below 20, primary above — no regression from main
- [ ] Auto-reload ON path: credits row shows `· auto-reload` hint; amber only when balance ≤ `rechargeThreshold`; primary otherwise; never red
- [ ] Auto-reload fetch returns 401/network error: credits row falls back to absolute thresholds, no crash
- [ ] Claude `BudgetStripView` behavior unchanged at 70%/85% thresholds
- [ ] Top-up notification fires when balance increases by > 50 between refreshes
- [ ] Notification copy uses "Auto-reload added credits" when `codexAutoReload?.isEnabled == true`, plain "New balance" otherwise
- [ ] First refresh after install: stores balance, no notification
- [ ] "Top-up events" toggle in Settings gates the notification (OFF → no notification even on real top-up)
- [ ] Demo: frames 0–8 show red/amber without hint; frame 9 shows balance jump and fires notification; frames 10–27 show amber (not red) with `· auto-reload` hint

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ek8pjrWw6wK3o1W9f3cb83)_