### PR TITLE
fix: primary caption color follows gauge state, not just primary metric

### DIFF
--- a/AIQuota/Views/CircularGaugeView.swift
+++ b/AIQuota/Views/CircularGaugeView.swift
@@ -36,9 +36,16 @@ struct CircularGaugeView: View {
 
     private static let amber = Color(red: 1.0, green: 0.65, blue: 0.0)
 
+    /// Mirrors the gauge's overall `statusColor` (worst-of primary & secondary) so the
+    /// primary caption never reads as "calm" when the gauge itself is in caution or
+    /// danger. Previously this used only the primary metric's own state, which made
+    /// the 5h reset caption stay purple while the arcs and 7d caption went red.
     private var primaryCaptionStyle: AnyShapeStyle {
-        if primaryLimitReached || primaryPercent >= 95 { return AnyShapeStyle(.red.opacity(0.8)) }
-        if primaryPercent >= 85 { return AnyShapeStyle(Self.amber) }
+        let worst = max(primaryPercent, secondaryPercent)
+        if primaryLimitReached || secondaryLimitReached || worst >= 95 {
+            return AnyShapeStyle(.red.opacity(0.8))
+        }
+        if worst >= 85 { return AnyShapeStyle(Self.amber) }
         return AnyShapeStyle(Self.accent.opacity(0.85))
     }
 


### PR DESCRIPTION
## Diagnosis

The gauge's arcs, percentage labels, and secondary caption all use \`statusColor\` (worst-of primary & secondary). The **primary** caption did not — it inspected only \`primaryPercent\`/\`primaryLimitReached\`. So when the 7d window was at 100% but the 5h window was at 1%, the arcs went red, the 7d caption went red, but the 5h reset caption stayed purple. Visibly out of sync.

Single inconsistent function, single-spot fix.

## Before / after

In the user-reported screenshot:
- **Codex** (5h=1%, 7d=100%): arcs red, 7d caption red, 5h caption **was purple** → now red
- **Claude** (5h=6%, 7d=90%): arcs amber, 7d caption amber, 5h caption **was purple** → now amber

## Test plan

- [x] \`xcodebuild -scheme AIQuota\` clean
- [ ] Run the app, observe a gauge where the secondary metric is in amber/red territory while the primary is calm — both captions should now match the arc color