### PR TITLE
fix: quieter Extra-usage tint (drop red tier, gate amber on active gauge pressure)

### DIFF
--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -300,6 +300,7 @@ struct PopoverView: View {
                         compactRow(
                             "Extra",
                             "\(Int(extra.usedCredits))/\(extra.monthlyLimit)",
+                            labelTint: extraUsageTint(extra.utilization),
                             valueTint: extraUsageTint(extra.utilization)
                         )
                     }
@@ -309,15 +310,24 @@ struct PopoverView: View {
         }
     }
 
+    /// Amber from 85% all the way to 99%. We do NOT have a red text tier between
+    /// amber and the bar — the bar itself is the cliff signal. Two "imminent" tiers
+    /// (red text then red bar) is redundant noise and overstates the urgency, since
+    /// the user has real headroom until they actually hit the cap.
     private func extraUsageTint(_ utilization: Double) -> Color {
-        if utilization >= 95 { return .red }
         if utilization >= 85 { return Color(red: 1.0, green: 0.65, blue: 0.0) }
         return .primary
     }
 
-    private func compactRow(_ label: String, _ value: String, valueTint: Color = .primary, suffix: String? = nil) -> some View {
+    private func compactRow(
+        _ label: String,
+        _ value: String,
+        labelTint: Color = .secondary,
+        valueTint: Color = .primary,
+        suffix: String? = nil
+    ) -> some View {
         HStack(spacing: 5) {
-            Text(label + ":").font(.caption2).foregroundStyle(.secondary)
+            Text(label + ":").font(.caption2).foregroundStyle(labelTint)
             Text(value).font(.caption2.monospacedDigit().bold())
                 .foregroundStyle(valueTint)
             if let suffix {

--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -296,12 +296,17 @@ struct PopoverView: View {
                 if let extra = usage.extraUsage, extra.isEnabled {
                     if extra.utilization >= BudgetStripView.showThreshold {
                         BudgetStripView(extra: extra)
-                    } else {
+                    } else if let tint = extraUsageTint(extra, usage: usage) {
                         compactRow(
                             "Extra",
                             "\(Int(extra.usedCredits))/\(extra.monthlyLimit)",
-                            labelTint: extraUsageTint(extra.utilization),
-                            valueTint: extraUsageTint(extra.utilization)
+                            labelTint: tint,
+                            valueTint: tint
+                        )
+                    } else {
+                        compactRow(
+                            "Extra",
+                            "\(Int(extra.usedCredits))/\(extra.monthlyLimit)"
                         )
                     }
                 }
@@ -310,13 +315,21 @@ struct PopoverView: View {
         }
     }
 
-    /// Amber from 85% all the way to 99%. We do NOT have a red text tier between
-    /// amber and the bar — the bar itself is the cliff signal. Two "imminent" tiers
-    /// (red text then red bar) is redundant noise and overstates the urgency, since
-    /// the user has real headroom until they actually hit the cap.
-    private func extraUsageTint(_ utilization: Double) -> Color {
-        if utilization >= 85 { return Color(red: 1.0, green: 0.65, blue: 0.0) }
-        return .primary
+    /// Amber color for the Extra row, but only when there's an *active spending
+    /// pressure* signal from the gauges. If the 5h and 7d windows are both calm
+    /// (< 85%), monthly extra utilization at 85-99% isn't actionable in the
+    /// moment — the user isn't burning through anything right now, so the row
+    /// stays in default colors. Once a gauge hits amber, we know more usage is
+    /// imminent and the monthly headroom suddenly matters.
+    ///
+    /// Returns nil to mean "no tint" so the call site can fall back to compactRow's
+    /// default label-secondary / value-primary styling rather than overriding both
+    /// to the same color.
+    private func extraUsageTint(_ extra: ClaudeUsage.ExtraUsage, usage: ClaudeUsage) -> Color? {
+        let extraInWarning = extra.utilization >= 85
+        let gaugePressure = max(usage.fiveHourUtilization, usage.sevenDayUtilization) >= 85
+        guard extraInWarning, gaugePressure else { return nil }
+        return Color(red: 1.0, green: 0.65, blue: 0.0)
     }
 
     private func compactRow(

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
@@ -14,7 +14,7 @@ struct PopoverTypographyTests {
         #expect(!popoverSource.contains(#"secondaryLabel: "7-day""#))
 
         #expect(popoverSource.contains(#".font(.system(size: 13, weight: .medium))"#))
-        #expect(popoverSource.contains(#"Text(label + ":").font(.caption2).foregroundStyle(.secondary)"#))
+        #expect(popoverSource.contains(#"Text(label + ":").font(.caption2).foregroundStyle(labelTint)"#))
         #expect(popoverSource.contains(#"Text(value).font(.caption2.monospacedDigit().bold())"#))
         #expect(!popoverSource.contains(#".font(.system(size: 13, weight: .bold).monospacedDigit())"#))
 
@@ -43,7 +43,8 @@ struct PopoverTypographyTests {
         // Credits row uses a dedicated text-first component, not a custom icon row.
         #expect(popoverSource.contains("CodexCreditsRow(balance: balance, autoReload: autoReload)"))
         #expect(popoverSource.contains("compactRow("))
-        #expect(popoverSource.contains(#"private func compactRow(_ label: String, _ value: String, valueTint: Color = .primary, suffix: String? = nil) -> some View"#))
+        #expect(popoverSource.contains(#"labelTint: Color = .secondary"#))
+        #expect(popoverSource.contains(#"valueTint: Color = .primary"#))
         #expect(!popoverSource.contains(#"Image(systemName: icon)"#))
         #expect(!popoverSource.contains(#"compactRow("Credits", "\(Int(balance))", "creditcard.fill")"#))
         #expect(!popoverSource.contains(#"compactRow("Extra", "\(Int(extra.usedCredits))/\(extra.monthlyLimit)", "plus.circle.fill")"#))

--- a/docs/budget-warning-design.md
+++ b/docs/budget-warning-design.md
@@ -26,10 +26,16 @@ Current rules:
 
 | Monthly extra utilization | Treatment |
 |---|---|
-| `< 85%` | `Extra` text in primary |
-| `85%...94%` | `Extra` text in amber |
-| `95%...99%` | `Extra` text in red |
+| `< 85%` | `Extra` row in primary / secondary |
+| `85%...99%` | `Extra` label and value both in amber |
 | `>= 100%` | `BudgetStripView` |
+
+There is intentionally no red text tier between amber and the bar. The bar is
+the cliff signal; pairing it with a red text tier just below it would mean two
+"imminent" indicators back-to-back, which overstates the urgency and makes the
+popover feel noisier than the situation actually is. At 95% utilization the
+user still has real headroom — amber is the right "heads up" level until the
+bar actually appears.
 
 Important: this tinting is based only on the monthly extra cap. It should not
 inherit the 5-hour or 7-day gauge state. For example, if the Claude 5-hour ring

--- a/docs/budget-warning-design.md
+++ b/docs/budget-warning-design.md
@@ -24,11 +24,12 @@ monthly extra cap has been reached.
 
 Current rules:
 
-| Monthly extra utilization | Treatment |
-|---|---|
-| `< 85%` | `Extra` row in primary / secondary |
-| `85%...99%` | `Extra` label and value both in amber |
-| `>= 100%` | `BudgetStripView` |
+| Monthly extra utilization | 5h or 7d gauge state | Treatment |
+|---|---|---|
+| `< 85%` | any | `Extra` row in default (secondary label / primary value) |
+| `85%...99%` | both gauges `< 85%` | `Extra` row in default — no active pressure |
+| `85%...99%` | either gauge `>= 85%` | `Extra` label and value both in amber |
+| `>= 100%` | any | `BudgetStripView` (bar is a cap-hit fact, not gated on gauges) |
 
 There is intentionally no red text tier between amber and the bar. The bar is
 the cliff signal; pairing it with a red text tier just below it would mean two
@@ -37,9 +38,17 @@ popover feel noisier than the situation actually is. At 95% utilization the
 user still has real headroom — amber is the right "heads up" level until the
 bar actually appears.
 
-Important: this tinting is based only on the monthly extra cap. It should not
-inherit the 5-hour or 7-day gauge state. For example, if the Claude 5-hour ring
-is amber at 93% but monthly extra is 79%, `Extra` should remain primary.
+The gauge-pressure gate matters because monthly extra at, say, 92% utilization
+isn't an immediate problem if the user isn't actively burning through any
+short-term windows. They could comfortably wait out the month. Coloring the
+Extra row in that calm-gauges case is premature warning: it implies action is
+needed when nothing is happening. The amber treatment earns its weight only
+when both signals point at the same problem — high monthly extra **and**
+active spending pressure converging.
+
+The bar at `>= 100%` is exempt from this gate: it reports a state ("cap hit"),
+not a prediction. The user is past the line regardless of momentary gauge
+activity, so the bar appears as soon as the line is crossed.
 
 ## Codex credits
 


### PR DESCRIPTION
## Problem

The Extra row was screaming red at 95% utilization in an otherwise quiet popover — overstating the urgency twice over:

1. **Red text below the bar is one tier too many.** The bar at 100% is the real cliff signal. A separate red text tier from 95-99% means two \"imminent\" indicators stacked back-to-back. With the user still having real headroom at 95%, the design read as panic when it should have read as heads-up.
2. **Coloring the row when both gauges are calm is premature warning.** Monthly extra at 92% isn't actionable in the moment if the user isn't burning through any 5h or 7d window. They could comfortably wait out the month. The amber treatment only earns its weight when both signals point at the same problem — high monthly extra **and** active spending pressure converging.

## Two-part fix

### Part 1: drop the red text tier

Collapse the tier ladder so amber covers `85%...99%` and the bar takes over at `>= 100%`. Bar is the only screaming layer.

| Before | After |
|---|---|
| `< 85%` primary | `< 85%` primary |
| `85-94%` amber | `85-99%` amber |
| `95-99%` red | *(removed)* |
| `>= 100%` bar | `>= 100%` bar |

### Part 2: gate the amber tint on gauge pressure

Amber now requires BOTH:

- `extra.utilization >= 85`, AND
- `max(fiveHourUtilization, sevenDayUtilization) >= 85`

When the gauges are calm, the Extra row stays in default colors regardless of monthly utilization — implemented by making `extraUsageTint` return `Optional<Color>` and falling back to `compactRow`'s defaults (secondary label, primary value) rather than overriding both to `.primary`.

The bar at `>= 100%` is intentionally **not** gated. It reports a state (cap hit), not a prediction — so it appears regardless of momentary gauge activity.

### labelTint plumbing preserved

The new `labelTint:` parameter on `compactRow` (which lets us tint both halves of a row together) stays — that part of the WIP is the right architecture. Tests reflect the new signature.

## Notes

- `docs/budget-warning-design.md` reflects both changes with rationale inline. The earlier \"this tinting should not inherit the 5h/7d gauge state\" note in the doc is replaced — the new rule is the opposite, and the reasoning is preserved alongside.
- The Codex side of the popover is unchanged; this is Claude-Extra-specific.

## Test plan

- [x] Build clean (`xcodebuild -scheme AIQuota`)
- [ ] Run the app with monthly extra in the 85-99% band:
  - [ ] Both 5h and 7d calm → Extra row stays in default (gray label, white value)
  - [ ] 5h amber or 7d amber → Extra row goes amber (both label and value)
- [ ] At `>= 100%` monthly extra: bar appears regardless of gauge state