### PR TITLE
style: drop bold on stats-row values to restore visual hierarchy

### DIFF
--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -341,7 +341,7 @@ struct PopoverView: View {
     ) -> some View {
         HStack(spacing: 5) {
             Text(label + ":").font(.caption2).foregroundStyle(labelTint)
-            Text(value).font(.caption2.monospacedDigit().bold())
+            Text(value).font(.caption2.monospacedDigit())
                 .foregroundStyle(valueTint)
             if let suffix {
                 Text(suffix).font(.caption2).foregroundStyle(.tertiary)
@@ -585,7 +585,7 @@ private struct CodexCreditsRow: View {
                     .font(.caption2)
                     .foregroundStyle(.secondary)
                 Text("\(Int(balance))")
-                    .font(.caption2.monospacedDigit().bold())
+                    .font(.caption2.monospacedDigit())
                     .foregroundStyle(valueTint)
                 Spacer(minLength: 4)
                 if let statusText {

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
@@ -15,7 +15,10 @@ struct PopoverTypographyTests {
 
         #expect(popoverSource.contains(#".font(.system(size: 13, weight: .medium))"#))
         #expect(popoverSource.contains(#"Text(label + ":").font(.caption2).foregroundStyle(labelTint)"#))
-        #expect(popoverSource.contains(#"Text(value).font(.caption2.monospacedDigit().bold())"#))
+        // Stats row values are intentionally NOT bold — the reset captions with their
+        // urgency color carry the real signal, and bolding metadata inverted the hierarchy.
+        #expect(popoverSource.contains(#"Text(value).font(.caption2.monospacedDigit())"#))
+        #expect(!popoverSource.contains(#"Text(value).font(.caption2.monospacedDigit().bold())"#))
         #expect(!popoverSource.contains(#".font(.system(size: 13, weight: .bold).monospacedDigit())"#))
 
         #expect(gaugeSource.contains(#".font(.system(size: 13, weight: .medium))"#))


### PR DESCRIPTION
## Problem

The stats rows below the gauge (\`Credits: 365\`, \`Extra: 8114/8500\`, \`Plan: Plus\`) used \`caption2.monospacedDigit().bold()\` for their values, while the reset captions above them (\`5h resets 9:20pm\`, \`7d resets Wed. 11:07am\`) used plain \`caption2\` with urgency tinting.

The reset captions are the *actionable* info — they tell you when something happens and how urgent it is via color. The stats values are metadata. Bolding the metadata inverted the hierarchy: the least-important text became the visually heaviest.

## Fix

Drop \`.bold()\` from:

- \`compactRow\` value rendering (used by Credits, Plan, Extra rows)
- \`CodexCreditsRow\` balance rendering

The bar in \`BudgetStripView\` keeps its bold — at \`>= 100%\` utilization it IS the alarm, so prominence is correct there. Same for percentages inside the circular gauge — those are the gauge's headline numbers, not metadata.

After the change, the bottom row reads as:

- Labels in secondary gray, values in primary (or amber when the auto-reload-aware logic kicks in)
- Reset captions in urgency color above

Color does the work of distinguishing role and urgency. Bold is no longer competing.

## Tests

- \`PopoverTypographyTests\` updated to pin the new non-bold style and forbid the old bold one.

## Test plan

- [x] Build clean
- [ ] Eyeball the popover — reset captions should be more visually present than the stats row; stats row should feel like metadata, not headlines