### PR TITLE
[codex] Make auto refresh follow quota activity

### DIFF
--- a/AIQuota/ViewModels/QuotaViewModel.swift
+++ b/AIQuota/ViewModels/QuotaViewModel.swift
@@ -192,10 +192,11 @@ final class QuotaViewModel {
     private var pathMonitorReady = false
     private let pathMonitor = NWPathMonitor()
     private let pathMonitorQueue = DispatchQueue(label: "ai.quota.pathmonitor")
-    private var appIsActive = false
     private var appLifecycleObservers: [NSObjectProtocol] = []
     private var workspaceLifecycleObservers: [NSObjectProtocol] = []
     private let popoverOpenRefreshMinimumInterval: TimeInterval = 30
+    private let recentServiceActivityDuration: TimeInterval = 10 * 60
+    private var lastServiceActivityAt: Date?
 
     // MARK: - Init
 
@@ -319,8 +320,6 @@ final class QuotaViewModel {
     }
 
     private func startLifecycleObservers() {
-        appIsActive = NSApplication.shared.isActive
-
         let notificationCenter = NotificationCenter.default
         appLifecycleObservers.append(
             notificationCenter.addObserver(
@@ -330,7 +329,6 @@ final class QuotaViewModel {
             ) { [weak self] _ in
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    self.appIsActive = true
                     self.restartAutoRefresh(immediateRefresh: true)
                 }
             }
@@ -343,7 +341,6 @@ final class QuotaViewModel {
             ) { [weak self] _ in
                 Task { @MainActor [weak self] in
                     guard let self else { return }
-                    self.appIsActive = false
                     self.restartAutoRefresh(immediateRefresh: false)
                 }
             }
@@ -441,6 +438,7 @@ final class QuotaViewModel {
                 logger.info("[CodexRefresh] auto-reload fetch failed — leaving codexAutoReload unchanged")
             }
 
+            recordServiceActivityIfNeeded(from: codexUsage, to: result)
             codexUsage = result
             lastRefreshedAt = .now
             SharedDefaults.saveUsage(result)
@@ -462,6 +460,7 @@ final class QuotaViewModel {
                 // Retry once after successful revalidation
                 do {
                     let result = try await codexClient.fetchUsage()
+                    recordServiceActivityIfNeeded(from: codexUsage, to: result)
                     codexUsage = result
                     lastRefreshedAt = .now
                     SharedDefaults.saveUsage(result)
@@ -521,6 +520,7 @@ final class QuotaViewModel {
         do {
             let result = try await claudeClient.fetchUsage()
             if shouldPreserveClaudeLastGood(result) { return }
+            recordServiceActivityIfNeeded(from: claudeUsage, to: result)
             claudeUsage = result
             lastRefreshedAt = .now
             SharedDefaults.saveClaudeUsage(result)
@@ -536,6 +536,7 @@ final class QuotaViewModel {
                 do {
                     let result = try await claudeClient.fetchUsage()
                     if self.shouldPreserveClaudeLastGood(result) { return }
+                    recordServiceActivityIfNeeded(from: claudeUsage, to: result)
                     claudeUsage = result
                     lastRefreshedAt = .now
                     SharedDefaults.saveClaudeUsage(result)
@@ -618,17 +619,33 @@ final class QuotaViewModel {
 
     private func autoRefreshContext() -> AutoRefreshContext {
         AutoRefreshContext(
-            appIsActive: appIsActive,
             lowPowerModeEnabled: ProcessInfo.processInfo.isLowPowerModeEnabled,
             networkAvailable: !pathMonitorReady || pathMonitor.currentPath.status == .satisfied,
             machineIdleSeconds: CGEventSource.secondsSinceLastEventType(
                 .combinedSessionState,
                 eventType: .null
             ),
-            hasCachedUsageData: codexUsage != nil || claudeUsage != nil,
+            serviceRecentlyActive: serviceWasRecentlyActive,
             codexNearThreshold: isCodexNearThreshold,
             claudeNearThreshold: isClaudeNearThreshold
         )
+    }
+
+    private var serviceWasRecentlyActive: Bool {
+        guard let lastServiceActivityAt else { return false }
+        return Date.now.timeIntervalSince(lastServiceActivityAt) < recentServiceActivityDuration
+    }
+
+    private func recordServiceActivityIfNeeded(from previous: CodexUsage?, to current: CodexUsage) {
+        if AutoRefreshActivity.changed(from: previous, to: current) {
+            lastServiceActivityAt = .now
+        }
+    }
+
+    private func recordServiceActivityIfNeeded(from previous: ClaudeUsage?, to current: ClaudeUsage) {
+        if AutoRefreshActivity.changed(from: previous, to: current) {
+            lastServiceActivityAt = .now
+        }
     }
 
     private var isCodexNearThreshold: Bool {

--- a/AIQuota/Views/Onboarding/Steps/ServicesStepView.swift
+++ b/AIQuota/Views/Onboarding/Steps/ServicesStepView.swift
@@ -105,7 +105,7 @@ private struct RefreshPreferencePicker: View {
             .pickerStyle(.segmented)
             .labelsHidden()
 
-            Text("Auto refreshes every 1 min when the app is active or usage is near a threshold, then slows down when idle.")
+            Text("Auto refreshes every 5 min, speeds up to 1 min when usage is changing or near a threshold, and slows down when your Mac is idle.")
                 .font(.footnote)
                 .foregroundStyle(.tertiary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/AIQuota/Views/SettingsView.swift
+++ b/AIQuota/Views/SettingsView.swift
@@ -33,7 +33,7 @@ struct SettingsView: View {
                     }
                     .pickerStyle(.segmented)
 
-                    Text("Auto refreshes every 1 min when the app is active or usage is near a threshold, then slows down when idle.")
+                    Text("Auto refreshes every 5 min, speeds up to 1 min when usage is changing or near a threshold, and slows down when your Mac is idle.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AutoRefreshPolicy.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Models/AutoRefreshPolicy.swift
@@ -1,11 +1,10 @@
 import Foundation
 
 public struct AutoRefreshContext: Sendable, Equatable {
-    public var appIsActive: Bool
     public var lowPowerModeEnabled: Bool
     public var networkAvailable: Bool
     public var machineIdleSeconds: TimeInterval
-    public var hasCachedUsageData: Bool
+    public var serviceRecentlyActive: Bool
     public var codexNearThreshold: Bool
     public var claudeNearThreshold: Bool
 
@@ -14,19 +13,17 @@ public struct AutoRefreshContext: Sendable, Equatable {
     }
 
     public init(
-        appIsActive: Bool,
         lowPowerModeEnabled: Bool,
         networkAvailable: Bool,
         machineIdleSeconds: TimeInterval,
-        hasCachedUsageData: Bool,
+        serviceRecentlyActive: Bool,
         codexNearThreshold: Bool,
         claudeNearThreshold: Bool
     ) {
-        self.appIsActive = appIsActive
         self.lowPowerModeEnabled = lowPowerModeEnabled
         self.networkAvailable = networkAvailable
         self.machineIdleSeconds = machineIdleSeconds
-        self.hasCachedUsageData = hasCachedUsageData
+        self.serviceRecentlyActive = serviceRecentlyActive
         self.codexNearThreshold = codexNearThreshold
         self.claudeNearThreshold = claudeNearThreshold
     }
@@ -36,26 +33,38 @@ public enum AutoRefreshPolicy {
     public static func interval(for context: AutoRefreshContext) -> TimeInterval {
         let idleSeconds = max(0, context.machineIdleSeconds)
 
-        if !context.networkAvailable || context.lowPowerModeEnabled || idleSeconds >= 1_800 {
-            return 1_800
-        }
-
-        if context.appIsActive || context.nearThreshold {
-            return 60
-        }
-
-        if !context.hasCachedUsageData {
-            return 300
-        }
-
-        if idleSeconds >= 900 {
-            return 900
-        }
-
-        if idleSeconds >= 300 {
+        if !context.networkAvailable || context.lowPowerModeEnabled || idleSeconds >= 300 {
             return 600
         }
 
+        if context.serviceRecentlyActive || context.nearThreshold {
+            return 60
+        }
+
         return 300
+    }
+}
+
+public enum AutoRefreshActivity {
+    public static func changed(from previous: CodexUsage?, to current: CodexUsage) -> Bool {
+        guard let previous else { return false }
+        return previous.weeklyUsedPercent != current.weeklyUsedPercent
+            || previous.hourlyUsedPercent != current.hourlyUsedPercent
+            || previous.limitReached != current.limitReached
+            || previous.allowed != current.allowed
+            || previous.creditBalance != current.creditBalance
+            || previous.approxLocalMessages != current.approxLocalMessages
+            || previous.approxCloudMessages != current.approxCloudMessages
+    }
+
+    public static func changed(from previous: ClaudeUsage?, to current: ClaudeUsage) -> Bool {
+        guard let previous else { return false }
+        return previous.fiveHourUtilization != current.fiveHourUtilization
+            || previous.sevenDayUtilization != current.sevenDayUtilization
+            || previous.extraUsage?.usedCredits != current.extraUsage?.usedCredits
+            || previous.extraUsage?.monthlyLimit != current.extraUsage?.monthlyLimit
+            || previous.extraUsage?.isEnabled != current.extraUsage?.isEnabled
+            || previous.spendLimit?.used != current.spendLimit?.used
+            || previous.spendLimit?.limit != current.spendLimit?.limit
     }
 }

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/AutoRefreshPolicyTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/AutoRefreshPolicyTests.swift
@@ -2,56 +2,133 @@ import XCTest
 @testable import AIQuotaKit
 
 final class AutoRefreshPolicyTests: XCTestCase {
-    func testActiveAppRefreshesEveryMinute() {
-        let interval = AutoRefreshPolicy.interval(for: makeContext(appIsActive: true))
+    func testRecentServiceActivityRefreshesEveryMinute() {
+        let interval = AutoRefreshPolicy.interval(for: makeContext(serviceRecentlyActive: true))
         XCTAssertEqual(interval, 60, accuracy: 0.5)
     }
 
     func testNearThresholdRefreshesEveryMinute() {
         let interval = AutoRefreshPolicy.interval(
-            for: makeContext(appIsActive: false, codexNearThreshold: true)
+            for: makeContext(codexNearThreshold: true)
         )
         XCTAssertEqual(interval, 60, accuracy: 0.5)
     }
 
-    func testNormalIdleUseRefreshesEveryFiveMinutes() {
+    func testNormalMacUseRefreshesEveryFiveMinutes() {
         let interval = AutoRefreshPolicy.interval(for: makeContext(machineIdleSeconds: 120))
         XCTAssertEqual(interval, 300, accuracy: 0.5)
     }
 
-    func testLongerIdleUseBacksOffToTenThenFifteenMinutes() {
-        let tenMinuteInterval = AutoRefreshPolicy.interval(for: makeContext(machineIdleSeconds: 600))
-        XCTAssertEqual(tenMinuteInterval, 600, accuracy: 0.5)
-
-        let fifteenMinuteInterval = AutoRefreshPolicy.interval(for: makeContext(machineIdleSeconds: 1_200))
-        XCTAssertEqual(fifteenMinuteInterval, 900, accuracy: 0.5)
+    func testIdleMacBacksOffToTenMinutes() {
+        let interval = AutoRefreshPolicy.interval(for: makeContext(machineIdleSeconds: 300))
+        XCTAssertEqual(interval, 600, accuracy: 0.5)
     }
 
-    func testOfflineOrLowPowerBacksOffToThirtyMinutes() {
+    func testOfflineOrLowPowerBacksOffToTenMinutes() {
         let offlineInterval = AutoRefreshPolicy.interval(for: makeContext(networkAvailable: false))
-        XCTAssertEqual(offlineInterval, 1_800, accuracy: 0.5)
+        XCTAssertEqual(offlineInterval, 600, accuracy: 0.5)
 
         let lowPowerInterval = AutoRefreshPolicy.interval(for: makeContext(lowPowerModeEnabled: true))
-        XCTAssertEqual(lowPowerInterval, 1_800, accuracy: 0.5)
+        XCTAssertEqual(lowPowerInterval, 600, accuracy: 0.5)
+    }
+
+    func testIdleAndPowerSavingOverrideFastModes() {
+        let interval = AutoRefreshPolicy.interval(
+            for: makeContext(
+                lowPowerModeEnabled: true,
+                serviceRecentlyActive: true,
+                codexNearThreshold: true
+            )
+        )
+        XCTAssertEqual(interval, 600, accuracy: 0.5)
+    }
+
+    func testCodexActivityIgnoresFetchTimeAndResetCountdownChanges() {
+        let previous = makeCodexUsage(fetchedAt: Date(timeIntervalSince1970: 100))
+        let unchanged = makeCodexUsage(
+            resetAfterSeconds: 240,
+            fetchedAt: Date(timeIntervalSince1970: 160)
+        )
+        let changed = makeCodexUsage(
+            hourlyUsedPercent: 13,
+            fetchedAt: Date(timeIntervalSince1970: 160)
+        )
+
+        XCTAssertFalse(AutoRefreshActivity.changed(from: previous, to: unchanged))
+        XCTAssertTrue(AutoRefreshActivity.changed(from: previous, to: changed))
+    }
+
+    func testClaudeActivityTracksUsageButIgnoresFetchTime() {
+        let previous = makeClaudeUsage(
+            fiveHourUtilization: 12,
+            fetchedAt: Date(timeIntervalSince1970: 100)
+        )
+        let unchanged = makeClaudeUsage(
+            fiveHourUtilization: 12,
+            fetchedAt: Date(timeIntervalSince1970: 160)
+        )
+        let changed = makeClaudeUsage(
+            fiveHourUtilization: 12.5,
+            fetchedAt: Date(timeIntervalSince1970: 160)
+        )
+
+        XCTAssertFalse(AutoRefreshActivity.changed(from: previous, to: unchanged))
+        XCTAssertTrue(AutoRefreshActivity.changed(from: previous, to: changed))
     }
 
     private func makeContext(
-        appIsActive: Bool = false,
         lowPowerModeEnabled: Bool = false,
         networkAvailable: Bool = true,
         machineIdleSeconds: TimeInterval = 0,
-        hasCachedUsageData: Bool = true,
+        serviceRecentlyActive: Bool = false,
         codexNearThreshold: Bool = false,
         claudeNearThreshold: Bool = false
     ) -> AutoRefreshContext {
         AutoRefreshContext(
-            appIsActive: appIsActive,
             lowPowerModeEnabled: lowPowerModeEnabled,
             networkAvailable: networkAvailable,
             machineIdleSeconds: machineIdleSeconds,
-            hasCachedUsageData: hasCachedUsageData,
+            serviceRecentlyActive: serviceRecentlyActive,
             codexNearThreshold: codexNearThreshold,
             claudeNearThreshold: claudeNearThreshold
+        )
+    }
+
+    private func makeCodexUsage(
+        hourlyUsedPercent: Int = 12,
+        resetAfterSeconds: Int = 300,
+        fetchedAt: Date
+    ) -> CodexUsage {
+        CodexUsage(
+            weeklyUsedPercent: 25,
+            weeklyResetAt: Date(timeIntervalSince1970: 10_000),
+            weeklyResetAfterSeconds: 9_000,
+            hourlyUsedPercent: hourlyUsedPercent,
+            hourlyResetAt: Date(timeIntervalSince1970: 1_000),
+            hourlyResetAfterSeconds: resetAfterSeconds,
+            hourlyWindowSeconds: 18_000,
+            limitReached: false,
+            allowed: true,
+            planType: "plus",
+            creditBalance: 100,
+            approxLocalMessages: [10, 100],
+            approxCloudMessages: [2, 20],
+            fetchedAt: fetchedAt
+        )
+    }
+
+    private func makeClaudeUsage(
+        fiveHourUtilization: Double,
+        fetchedAt: Date
+    ) -> ClaudeUsage {
+        ClaudeUsage(
+            fiveHourUtilization: fiveHourUtilization,
+            fiveHourResetsAt: Date(timeIntervalSince1970: 1_000),
+            sevenDayUtilization: 25,
+            sevenDayResetsAt: Date(timeIntervalSince1970: 10_000),
+            extraUsage: nil,
+            planLabel: .pro,
+            fetchedAt: fetchedAt
         )
     }
 }

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/RefreshSettingsTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/RefreshSettingsTests.swift
@@ -63,8 +63,8 @@ struct RefreshSettingsTests {
             encoding: .utf8
         )
 
-        #expect(settingsSource.contains("Auto refreshes every 1 min when the app is active or usage is near a threshold, then slows down when idle."))
+        #expect(settingsSource.contains("Auto refreshes every 5 min, speeds up to 1 min when usage is changing or near a threshold, and slows down when your Mac is idle."))
         #expect(servicesSource.contains("How often should AIQuota refresh?"))
-        #expect(servicesSource.contains("Auto refreshes every 1 min when the app is active or usage is near a threshold, then slows down when idle."))
+        #expect(servicesSource.contains("Auto refreshes every 5 min, speeds up to 1 min when usage is changing or near a threshold, and slows down when your Mac is idle."))
     }
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The marketing site in `docs/` follows the shared Codex web preview convention us
 - **Service details that matter** — reset timers, plan info, credits or extra usage, and clear warning states are visible at a glance
 - **Desktop widgets** — polished widget variants for single-service and dual-service monitoring, including configurable small and medium widgets plus a large two-service layout
 - **Graceful empty and loading states** — widgets and the popover keep a stable layout when a service is disconnected, restoring, or waiting on fresh data
-- **Adaptive refresh controls** — choose `Auto` to refresh every minute when the app is active or quota is near a threshold, then back off automatically when idle, offline, or on low power
+- **Adaptive refresh controls** — choose `Auto` for a five-minute baseline that speeds up to every minute while usage is changing or near a threshold, then backs off when the Mac is idle, offline, or on low power
 - **Guided onboarding** — first launch walks through connecting services, refresh preferences, notifications, and widget setup; if both services are connected, onboarding also asks which one should drive the menu bar icon
 - **Single-service adaptation** — when only one service is enrolled, the app and widgets avoid dead space instead of pretending there should be a second column
 - **ChatGPT and Claude sign-in** — reuses an existing Claude Code or Codex CLI login when available, and falls back to a browser-backed session otherwise (including Google sign-in, which opens in its own popup window); app authentication comes only from live OAuth or WebKit sessions, while widget credentials are stored separately for background refresh


### PR DESCRIPTION
## Summary

Reworks `Auto` refresh so it follows actual Codex and Claude usage activity instead of whether AIQuota happens to be the frontmost macOS app.

## Why

AIQuota is a menu bar utility, so it is almost never the active application. The previous policy therefore made the advertised one-minute behavior largely irrelevant: opening the popover already triggered an immediate refresh, while normal background operation usually fell back to a slower cadence.

The new policy uses changes in fetched quota data as the activity signal. This better matches the user intent: poll quickly while Codex or Claude is consuming quota, and avoid unnecessary requests when neither service appears active.

## Behavior

- Refresh immediately when the popover opens and cached data is at least 30 seconds old.
- Use a five-minute baseline while the Mac is in use.
- Switch to one-minute refreshes for ten minutes after meaningful Codex or Claude usage movement is detected.
- Continue using one-minute refreshes near usage limits or reset boundaries.
- Back off to ten minutes when the Mac is idle, offline, or in Low Power Mode.
- Refresh immediately after wake, network recovery, and app activation as before.

Activity detection compares meaningful usage fields such as window utilization, limit state, credit/message counts, extra usage, and spend. Fetch timestamps and ordinary reset countdown movement are intentionally ignored so they do not falsely keep fast mode alive.

## User-facing changes

- Updates the Auto explanation in Settings and onboarding.
- Updates the README feature description to match the implemented cadence.

## Validation

- `swift test --disable-sandbox --filter AutoRefreshPolicyTests`
- `swift test --disable-sandbox --filter RefreshSettingsTests`
- `xcodebuild -project AIQuota.xcodeproj -scheme AIQuota -configuration Debug -destination 'platform=macOS' build`
- `git diff --check`

The focused refresh tests pass and the macOS app builds successfully. The full package suite reached 102 tests but retained the repository's known shared auth/defaults state failures in unrelated coordinator tests; all refresh-policy and refresh-copy tests passed.
