### PR TITLE
Polish widget and popover quota UI

### DIFF
--- a/AIQuota/Views/PopoverView.swift
+++ b/AIQuota/Views/PopoverView.swift
@@ -36,7 +36,7 @@ struct PopoverView: View {
     @ViewBuilder
     private var popoverSurface: some View {
         if #available(macOS 26.0, *) {
-            Color.black.opacity(0.18)
+            Color.black.opacity(0.26)
         } else {
             // Sequoia's MenuBarExtra material is substantially more transparent
             // than Tahoe's glass treatment. Stabilize contrast while retaining a

--- a/AIQuotaWidget/Views/WidgetGaugeView.swift
+++ b/AIQuotaWidget/Views/WidgetGaugeView.swift
@@ -52,7 +52,7 @@ struct WidgetGaugeView: View {
                 // ── Outer track ───────────────────────────────────────
                 Circle()
                     .trim(from: 0, to: 0.75)
-                    .stroke(.fill.quaternary, style: StrokeStyle(lineWidth: outerLW, lineCap: .butt))
+                    .stroke(.fill.tertiary, style: StrokeStyle(lineWidth: outerLW, lineCap: .butt))
                     .rotationEffect(.degrees(135))
 
                 Circle()
@@ -63,7 +63,7 @@ struct WidgetGaugeView: View {
                 // ── Inner track (touching) ────────────────────────────
                 Circle()
                     .trim(from: 0, to: 0.75)
-                    .stroke(.fill.quaternary, style: StrokeStyle(lineWidth: innerLW, lineCap: .butt))
+                    .stroke(.fill.tertiary, style: StrokeStyle(lineWidth: innerLW, lineCap: .butt))
                     .rotationEffect(.degrees(135))
                     .padding(innerPad)
 

--- a/AIQuotaWidget/Views/WidgetMediumView.swift
+++ b/AIQuotaWidget/Views/WidgetMediumView.swift
@@ -66,7 +66,7 @@ private extension QuotaEntry {
                     )
                 )
             }
-            if let spent = usage.bonusCreditsSpentThisMonth {
+            if let spent = usage.bonusCreditsSpentThisMonth, spent > 0 {
                 detailRows.append(
                     WidgetDetailRowData(
                         label: "Spent",
@@ -108,7 +108,7 @@ private extension QuotaEntry {
                     tint: .secondary
                 ),
             ]
-            if let bonus = usage.bonusUsage {
+            if let bonus = usage.bonusUsage, bonus.spent > 0 {
                 detailRows.append(
                     WidgetDetailRowData(
                         label: "Spent",
@@ -376,11 +376,11 @@ private struct WidgetEmptyGaugeView: View {
             ZStack {
                 Circle()
                     .trim(from: 0, to: 0.75)
-                    .stroke(.fill.quaternary, style: StrokeStyle(lineWidth: size * 0.08, lineCap: .butt))
+                    .stroke(.fill.tertiary, style: StrokeStyle(lineWidth: size * 0.08, lineCap: .butt))
                     .rotationEffect(.degrees(135))
                 Circle()
                     .trim(from: 0, to: 0.75)
-                    .stroke(.fill.quaternary, style: StrokeStyle(lineWidth: size * 0.08, lineCap: .butt))
+                    .stroke(.fill.tertiary, style: StrokeStyle(lineWidth: size * 0.08, lineCap: .butt))
                     .rotationEffect(.degrees(135))
                     .padding(size * 0.08)
                 VStack(spacing: 4) {

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Auth/ClaudeAuthCoordinator.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Auth/ClaudeAuthCoordinator.swift
@@ -39,6 +39,7 @@ public actor ClaudeAuthCoordinator {
     private var capturedOrgId: String?
     private var capturedCookies: [HTTPCookie] = []
     private var cachedOAuthCredentials: ClaudeOAuthCredentials?
+    private var oauthDisabledForSession = false
 
     // MARK: Logger
 
@@ -283,6 +284,8 @@ public actor ClaudeAuthCoordinator {
     }
 
     public func loadOAuthCredentials(allowKeychain: Bool) throws -> ClaudeOAuthCredentials {
+        guard !oauthDisabledForSession else { throw ClaudeOAuthCredentialsError.notFound }
+
         let fileError: Error?
         do {
             let credentials = try oauthCredentialsLoader(false)
@@ -308,6 +311,11 @@ public actor ClaudeAuthCoordinator {
     }
 
     public func invalidateCachedOAuthCredentials() {
+        cachedOAuthCredentials = nil
+    }
+
+    public func disableOAuthForSession() {
+        oauthDisabledForSession = true
         cachedOAuthCredentials = nil
     }
 

--- a/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeClient.swift
+++ b/Packages/AIQuotaKit/Sources/AIQuotaKit/Networking/ClaudeClient.swift
@@ -37,11 +37,16 @@ public actor ClaudeClient {
                         await coordinator.invalidateCachedOAuthCredentials()
                         if policyBlocked {
                             oauthDisabledForSession = true
+                            await coordinator.disableOAuthForSession()
                         } else if status == 403 {
                             oauthPolicyFailures += 1
                             if oauthPolicyFailures >= 3 {
                                 oauthDisabledForSession = true
+                                await coordinator.disableOAuthForSession()
                             }
+                        } else if status == 401 {
+                            oauthDisabledForSession = true
+                            await coordinator.disableOAuthForSession()
                         }
                         recordAttempt(
                             source: .oauth,

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/ClaudeAuthCoordinatorTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/ClaudeAuthCoordinatorTests.swift
@@ -170,6 +170,40 @@ struct ClaudeAuthCoordinatorTests {
         #expect(keychainCalls.value == 1)
     }
 
+    @Test("signIn skips OAuth credentials after OAuth is disabled for the session")
+    func signInSkipsOAuthAfterSessionDisable() async throws {
+        let oauthCalls = LockIsolated<[Bool]>([])
+        let probeCalls = LockIsolated(0)
+        let sut = makeSUT(
+            probe: {
+                let count = probeCalls.withLock { calls in
+                    calls += 1
+                    return calls
+                }
+                return count == 1 ? .notFound : .found(orgId: "web-org", cookies: [])
+            },
+            oauthCredentialsLoader: { allowKeychain in
+                oauthCalls.withLock { $0.append(allowKeychain) }
+                return Self.oauthCredentials(accessToken: "stale-oauth-token")
+            }
+        )
+
+        await sut.bootstrap()
+        #expect(await sut.state == .authenticated)
+        await sut.disableOAuthForSession()
+        let revalidated = await sut.revalidateSessionAfterAuthFailure()
+        #expect(revalidated == false)
+        #expect(await sut.state == .unauthenticated)
+
+        try await sut.signIn()
+
+        #expect(await sut.state == .authenticated)
+        let context = try await sut.requestContext()
+        #expect(context.orgId == "web-org")
+        #expect(oauthCalls.value == [false])
+        #expect(probeCalls.value == 2)
+    }
+
     // MARK: - signOut
 
     @Test("signOut from authenticated transitions to signedOutByUser")

--- a/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
+++ b/Packages/AIQuotaKit/Tests/AIQuotaKitTests/PopoverTypographyTests.swift
@@ -92,7 +92,7 @@ struct PopoverTypographyTests {
         let popoverSource = try String(contentsOf: repoRoot.appending(path: "AIQuota/Views/PopoverView.swift"), encoding: .utf8)
 
         #expect(popoverSource.contains("if #available(macOS 26.0, *)"))
-        #expect(popoverSource.contains("Color.black.opacity(0.18)"))
+        #expect(popoverSource.contains("Color.black.opacity(0.26)"))
         #expect(popoverSource.contains("Color(nsColor: .windowBackgroundColor).opacity(0.92)"))
     }
 


### PR DESCRIPTION
## Summary
- make widget empty gauge tracks use semantic tertiary fill for better contrast
- hide zero-value widget spent rows using the same conditions as the main popover
- strengthen the macOS 26 popover backing for legibility over bright content
- disable rejected Claude OAuth credentials for the current app session so manual sign-in can fall back to web login

## Tests
- swift test --filter ClaudeAuthCoordinatorTests
- swift test --filter PopoverTypographyTests
- xcodebuild build -project AIQuota.xcodeproj -scheme AIQuota -configuration Debug -destination 'platform=macOS'

Note: full swift test still has an unrelated AuthInstallStateTests shared-UserDefaults failure observed before this commit.